### PR TITLE
Fix GitHub URLs to use vllm-qaic repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ In general, contributors should develop on branches based off of `main` and pull
 
     The `-u` is shorthand for `--set-upstream`. This will set up the tracking reference so subsequent runs of `git push` or `git pull` can omit the remote and branch.
 
-1. [Submit a pull request](https://github.com/qualcomm/<REPLACE-ME>/pulls) from your branch to `main`.
+1. [Submit a pull request](https://github.com/qualcomm/vllm-qaic/pulls) from your branch to `main`.
 1. Pat yourself on the back and wait for your pull request to be reviewed.
 
 ## Security Analysis of Pull Requests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@ How to Report a Potential Vulnerability?
 
 If you would like to report a public issue (for example, one with a released
 CVE number), please report it as a
-[GitHub issue](https://github.com/qualcomm/REPLACE-ME/issues/new).
+[GitHub issue](https://github.com/qualcomm/vllm-qaic/issues/new).
 If you have a patch ready, submit it following the same procedure as any
 other patch as described in [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
Fix Repo url  in CONTRIBUTING.md and SECURITY.md links.