### PR TITLE
fix qaic_utils import

### DIFF
--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -230,7 +230,7 @@ class QaicPlatform(Platform):
         # before any downstream code reads from it, mirroring what
         # _get_qaic_compile_config previously did via its local _clean_config.
         if override_qaic_config:
-            from vllm.utils.qaic_utils import _clean_config
+            from vllm_qaic.utils.qaic_utils import _clean_config
 
             cleaned = _clean_config(override_qaic_config, vllm_config)
             override_qaic_config.update(cleaned)


### PR DESCRIPTION
This change fixes the import of qaic_utils from vllm_qaic. The erroneous implementation was trying to import qaic_utils from the vllm package, which would work in the legacy qaic-specific vllm fork but not with the vllm-qaic plugin which relies on vllm cloned from the public repository