### PR TITLE
Improve install UX: config banner and disk-space pre-flight for triton-cpu installation

### DIFF
--- a/docs/docs/getting_started/installation/aot_mode.md
+++ b/docs/docs/getting_started/installation/aot_mode.md
@@ -12,13 +12,26 @@ AOT (Ahead-of-Time) mode uses the QEfficient library to compile models into Qual
 ./scripts/install.sh aot
 ```
 
+!!! info "Configuration banner"
+    Before installation starts, `install.sh` prints a full summary of every version and
+    setting it will use (vllm, vllm-qaic, torch, qeff branch, target device, triton-cpu
+    state). Review the banner output and override any variable before re-running.
+
 ??? example "Optional environment overrides"
     ```bash
     # Pin transformers version
     TRANSFORMERS_VERSION_AOT=4.55.3 ./scripts/install.sh aot
 
     # Enable triton-cpu backend (for Speculative Decoding)
+    # triton-cpu is a large C++ build — requires ~10 GB of free disk space at TRITON_CPU_SRC
     TRITON_CPU=1 ./scripts/install.sh aot
+
+    # Redirect the triton-cpu clone+build to a filesystem with more space
+    # (use when $HOME has limited disk space or a user quota)
+    TRITON_CPU=1 TRITON_CPU_SRC=/path/with/more/space/triton-cpu ./scripts/install.sh aot
+
+    # Skip the disk-space pre-flight check entirely
+    TRITON_CPU=1 TRITON_CPU_SKIP_DISK_CHECK=1 ./scripts/install.sh aot
 
     # Install from pre-built wheel
     VLLM_QAIC_INSTALL_SOURCE=wheel \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,10 @@ source .venv/bin/activate
 
 The script handles all dependency ordering, version pinning, and `uv`/`pip` detection automatically.
 
+> **Configuration banner:** Before installation starts, `install.sh` prints a full summary of
+> every version and setting it will use (vllm, vllm-qaic, torch, qeff branch, target device,
+> triton-cpu state). Review it and override any variable before re-running.
+
 ### AOT mode — `install.sh`
 
 ```bash
@@ -93,7 +97,15 @@ TRANSFORMERS_VERSION_AOT=4.55.3 ./scripts/install.sh aot
 TRANSFORMERS_VERSION_PYT=4.57.3 ./scripts/install.sh pyt
 
 # Enable triton-cpu backend for AOT Speculative Decoding
+# triton-cpu is a large C++ build — requires ~10 GB of free disk space at TRITON_CPU_SRC
 TRITON_CPU=1 ./scripts/install.sh aot
+
+# Redirect the triton-cpu clone+build to a filesystem with more space
+# (use when $HOME has limited disk space or a user quota)
+TRITON_CPU=1 TRITON_CPU_SRC=/path/with/more/space/triton-cpu ./scripts/install.sh aot
+
+# Skip the disk-space pre-flight check entirely
+TRITON_CPU=1 TRITON_CPU_SKIP_DISK_CHECK=1 ./scripts/install.sh aot
 
 # Force wheel install from a custom SDK path
 VLLM_QAIC_INSTALL_SOURCE=wheel VLLM_QAIC_SDK_PATH=/path/to/sdk ./scripts/install.sh pyt
@@ -280,5 +292,6 @@ All version constants are defined in [`scripts/utility.sh`](../scripts/utility.s
 | `TRITON_CPU_COMMIT` | `e60f448f...` | Pinned triton-cpu commit hash |
 | `TRITON_CPU_SRC` | `$HOME/triton-cpu` | Clone destination for triton-cpu source |
 | `TRITON_CPU_COMPILE_MAX_JOBS` | `4` | Parallel build jobs for triton-cpu compilation |
+| `TRITON_CPU_SKIP_DISK_CHECK` | `0` | Set to `1` to skip the 10 GB disk-space pre-flight check |
 | `TORCH_QAIC_BASE_PATH` | `/opt/qti-aic/integrations/torch_qaic` | SDK path for torch_qaic wheels |
 | `VLLM_QAIC_SDK_PATH` | `/opt/qti-aic/integrations/vllm_qaic` | SDK path for pre-built vllm-qaic wheels |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,10 +94,33 @@ echo ""
 echo "========================================================"
 echo "  vllm-qaic installer"
 echo "  mode     : ${MODE}"
-echo "  source   : ${INSTALL_SOURCE}"
-echo "  triton-cpu: $([ "${TRITON_CPU}" = "1" ] && echo "enabled (${TRITON_CPU_SRC})" || echo "disabled")"
+echo "  source   : ${INSTALL_SOURCE}$([ "${INSTALL_SOURCE}" = "source" ] && echo " (${REPO_ROOT})" || echo "")"
 echo "  python   : $(${PYTHON} --version)"
 echo "  env      : $(${PYTHON} -c 'import sys; print(sys.prefix)')"
+echo "  --------------------------------------------------------"
+if [ "${MODE}" = "aot" ]; then
+    echo "  vllm           : ${VLLM_VERSION}       vllm-qaic: ${VLLM_QAIC_VERSION}"
+    echo "  torch (AOT)    : ${TORCH_VERSION_AOT}  torchvision: ${TORCHVISION_VERSION_AOT}"
+    echo "  qeff branch    : ${QEFF_BRANCH}"
+    echo "  target device  : ${VLLM_TARGET_DEVICE_AOT}"
+    if [ "${TRITON_CPU}" = "1" ]; then
+        echo "  triton-cpu     : enabled"
+        echo "    src          : ${TRITON_CPU_SRC}"
+        echo "    commit       : ${TRITON_CPU_COMMIT}"
+        echo "    max jobs     : ${TRITON_CPU_COMPILE_MAX_JOBS}"
+    else
+        echo "  triton-cpu     : disabled  (set TRITON_CPU=1 to enable)"
+    fi
+else
+    echo "  vllm           : ${VLLM_VERSION}       vllm-qaic: ${VLLM_QAIC_VERSION}"
+    echo "  torch (PYT)    : ${TORCH_VERSION_PYT}  torchvision: ${TORCHVISION_VERSION_PYT}"
+    echo "  torchaudio     : ${TORCHAUDIO_VERSION_PYT}"
+    echo "  torch-qaic     : ${TORCH_QAIC_VERSION}"
+    echo "  target device  : ${VLLM_TARGET_DEVICE_PYT}"
+fi
+echo "  --------------------------------------------------------"
+echo "  Override any variable before running, e.g.:"
+echo "    TRITON_CPU=1 TRITON_CPU_SRC=/data/triton-cpu ./scripts/install.sh aot"
 echo "========================================================"
 echo ""
 

--- a/scripts/install_triton_cpu.sh
+++ b/scripts/install_triton_cpu.sh
@@ -25,6 +25,35 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utility.sh"
 
+# ── Disk space pre-flight ────────────────────────────────────────────────────
+# Triton-CPU is a large C++ build; running out of disk space or hitting a per-user
+# quota causes the build to fail.  This check tests filesystem available space.
+# NOTE: per-user quotas are invisible to df and cannot be pre-checked here —
+#       if the build later fails with "Disk quota exceeded", see the error message
+#       printed after the pip install step for how to redirect the build.
+# Walk up TRITON_CPU_SRC to find the first existing ancestor (the dir doesn't exist yet).
+if [ "${TRITON_CPU_SKIP_DISK_CHECK:-0}" != "1" ]; then
+    _chk="${TRITON_CPU_SRC}"
+    while [ ! -d "${_chk}" ]; do _chk="$(dirname "${_chk}")"; done
+    _avail_kb=$(df -Pk "${_chk}" | awk 'NR==2 {print $4}')
+    _need_kb=$(( 10 * 1024 * 1024 ))   # 10 GB in KB
+    if [ "${_avail_kb}" -lt "${_need_kb}" ]; then
+        _avail_gb=$(( _avail_kb / 1024 / 1024 ))
+        echo "ERROR: insufficient disk space for triton-cpu build." >&2
+        echo "  available  : ${_avail_gb} GB on filesystem containing ${_chk}" >&2
+        echo "  recommended: 10 GB  (C++ build consumes 5-10 GB)" >&2
+        echo "  build path : ${TRITON_CPU_SRC}" >&2
+        echo "" >&2
+        echo "  Redirect the build to a filesystem with more space:" >&2
+        echo "    export TRITON_CPU_SRC=/path/with/more/space/triton-cpu" >&2
+        echo "  Then re-run:  ./scripts/install.sh aot  (or install_triton_cpu.sh)" >&2
+        echo "" >&2
+        echo "  To skip this check:  export TRITON_CPU_SKIP_DISK_CHECK=1" >&2
+        exit 1
+    fi
+    unset _chk _avail_kb _need_kb _avail_gb
+fi
+
 # ── Clone / checkout triton-cpu ───────────────────────────────────────────────
 if [ ! -f "${TRITON_CPU_SRC}/python/setup.py" ]; then
     echo "INFO: triton-cpu not found at ${TRITON_CPU_SRC} — cloning..."
@@ -103,7 +132,18 @@ ${PIP} install "pybind11>=2.13.1" "ninja>=1.11.1"
 
 # ── Install (editable, no build isolation so it reuses existing torch) ──────
 echo "=== Building and installing triton-cpu (editable) ==="
-MAX_JOBS="${TRITON_CPU_COMPILE_MAX_JOBS:-4}" ${PIP} install -e "${TRITON_CPU_SRC}/python" --no-build-isolation
+if ! MAX_JOBS="${TRITON_CPU_COMPILE_MAX_JOBS:-4}" ${PIP} install -e "${TRITON_CPU_SRC}/python" --no-build-isolation; then
+    echo "" >&2
+    echo "ERROR: triton-cpu C++ build failed (see output above)." >&2
+    echo "  If the error mentions 'Disk quota exceeded' or 'No space left on device':" >&2
+    echo "    df shows filesystem free space but cannot see per-user quota limits." >&2
+    echo "    Your quota on the filesystem containing ${TRITON_CPU_SRC} may be exhausted." >&2
+    echo "    Redirect the build to a quota-free filesystem:" >&2
+    echo "      export TRITON_CPU_SRC=/tmp/triton-cpu                      # tmpfs, no user quota" >&2
+    echo "      export TRITON_CPU_SRC=/prj/crd/.../scratch/triton-cpu      # scratch space" >&2
+    echo "    Then re-run:  ./scripts/install.sh aot  (or install_triton_cpu.sh)" >&2
+    exit 1
+fi
 
 # ── Sanity check ────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Installing triton-cpu for AOT SpD hits a silent build failure when default path `$HOME` does not have enough storage to install triton-cpu backend.

This PR makes two improvements to prevent that class of failure from being silent.

---

## 1. Expanded configuration banner (`scripts/install.sh`)

The startup banner previously showed only mode, install source, python version,
and a single triton-cpu enabled/disabled line.

It now shows the full install configuration before anything is downloaded or
built, grouped by mode:

**AOT mode (TRITON_CPU=1):**
```
========================================================
  vllm-qaic installer
  mode     : aot
  source   : source (/path/to/vllm-qaic)
  python   : Python 3.10.12
  env      : /path/to/.venv
  --------------------------------------------------------
  vllm           : 0.23.0       vllm-qaic: 1.22
  torch (AOT)    : 2.7.0+cpu  torchvision: 0.22.0+cpu
  qeff branch    : release/v1.22.0
  target device  : empty
  triton-cpu     : enabled
    src          : /prj/.../scratch/triton-cpu
    commit       : e60f448f8f197073b75d6d3e77347414a5db3ee7
    max jobs     : 4
  --------------------------------------------------------
  Override any variable before running, e.g.:
    TRITON_CPU=1 TRITON_CPU_SRC=/data/triton-cpu ./scripts/install.sh aot
========================================================
```

The triton-cpu `src` path is now visible upfront, so users can see at a glance
whether it resolves to a quota-limited filesystem before committing to a 30-minute
build.

---

## 2. Disk-space pre-flight and build error handler (`scripts/install_triton_cpu.sh`)

### Pre-flight check (before any git clone)

- Walks up `TRITON_CPU_SRC` to the first existing ancestor directory (the clone
  target won't exist yet) and checks available space with `df -Pk`.
- Errors early with an actionable message if < 10 GB available, including the
  exact `TRITON_CPU_SRC` path and how to redirect it.
- Escape hatch: `TRITON_CPU_SKIP_DISK_CHECK=1`.

### Build error handler (wraps `pip install -e`)

If the C++ build fails for any reason, prints a named explanation covering the
`Disk quota exceeded` / `No space left on device` cases, with specific guidance
on redirecting `TRITON_CPU_SRC` to a quota-free filesystem.

---

## Validation

### Disk-space check — tight filesystem
Ran with `TRITON_CPU_SRC=/boot/triton-cpu` (`/boot` has 882 MB available).
Script exited 1 before any git clone, printing the actionable error message.
No artifacts were written.

### Disk-space check — adequate filesystem
Default `TRITON_CPU_SRC` path resolves to a filesystem with 637 GB available.
Check passes silently.

### NFS quota scenario (reproduces the original failure)
Ran full `TRITON_CPU=1 ./scripts/install.sh aot` with `TRITON_CPU_SRC` on
`$HOME` (637 GB filesystem free, but per-user NFS quota exhausted mid-build).
The `df` pre-flight passed (as expected — `df` cannot see user quota), and the
build failed with `[Errno 122] Disk quota exceeded`. The new error handler
printed a named explanation and redirect instructions instead of a silent exit.

### Full AOT + triton-cpu install — scratch NFS (no quota)
Ran with `TRITON_CPU_SRC` on a scratch NFS mount (3.8 TB, separate server from
`$HOME`, no per-user quota). All four install steps completed successfully:

| Step | Package | Result |
|------|---------|--------|
| 1 | QEfficient (torch 2.7.0+cpu) | ✓ |
| 2 | vLLM deps + vLLM 0.23.0 | ✓ |
| 3 | vllm-qaic-aot | ✓ |
| 4 | triton-cpu (`OK: cpu backend is active`) | ✓ |

Final install into `.venv/` in the repo root also completed successfully with
the same result.
