### PR TITLE
Rework prefill_seq_len sourcing, logits dtype handling, and RMS-norm …

### DIFF
--- a/csrc/add_rms_norm/dispatch.cpp
+++ b/csrc/add_rms_norm/dispatch.cpp
@@ -37,16 +37,18 @@ extern "C" uint32_t rms_norm_multi_nsp_bf16(const AicJitEntryPointConfig *cfg,
 
 // rms_norm_dispatch — single entry point called by the wrapper.
 // Pointer layout (same as the individual kernels):
-//   ptrs->pointers[0] : attn_out  [M, N]
-//   ptrs->pointers[1] : x         [M, N]
-//   ptrs->pointers[2] : weight    [N]
-//   ptrs->pointers[3] : dst       [M, N]  (normed output)
-//   ptrs->pointers[4] : residual  [M, N]  (attn_out + x)
-//   ptrs->pointers[5] : params    float[4] = {epsilon, M, N, dtype}
+//   ptrs->pointers[0] : attn_out    (input)
+//   ptrs->pointers[1] : x           (input)
+//   ptrs->pointers[2] : weight      [N]
+//   ptrs->pointers[3] : dst         (normed output)
+//   ptrs->pointers[4] : residual    (attn_out + x)
+//   ptrs->pointers[5] : epsilon     float scalar
+//   ptrs->pointers[6] : N           int scalar (weight.numel())
+//   ptrs->pointers[7] : total_elems int scalar (attn_out.numel())
+//   ptrs->pointers[8] : dtype       int scalar (0=FP16, 1=BF16)
 QAIC_KERNEL_API uint32_t rms_norm_dispatch(const AicJitEntryPointConfig *cfg,
                                            const AicJitPointerArray *ptrs) {
-  const float *params = (const float *)ptrs->pointers[5];
-  const int dtype = (int)params[3];
+  const int dtype = *(const int32_t *)ptrs->pointers[8];
 
 #if __HEXAGON_ARCH__ >= 81
   if (dtype == QAIC_RMS_NORM_DTYPE_BF16) {

--- a/csrc/add_rms_norm/kernel.cpp
+++ b/csrc/add_rms_norm/kernel.cpp
@@ -154,8 +154,9 @@ extern "C" void _single_nsp_rms_norm(
 }
 
 // NSP entry point: drives rms_norm row-by-row over an (M, N) matrix.
-// Pointers layout: [0]=attn_out, [1]=x, [2]=weight, [3]=residual_out, [4]=dst,
-// [5]=params{eps,M,N} Each core owns a stripe of rows (coreID, coreID+numCores,
+// Pointers layout: [0]=attn_out, [1]=x, [2]=weight, [3]=residual_out, [4]=dst
+//   [5]=epsilon (float scalar), [6]=M (int scalar), [7]=N (int scalar)
+// Each core owns a stripe of rows (coreID, coreID+numCores,
 // ...). Double-buffered DMA (slots 0/1) overlaps prefetch of row m+1 with
 // compute on row m.
 QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
@@ -165,11 +166,10 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
   const float16 *weight_ddr = (const float16 *)ptrs->pointers[2];
   float16 *out_ddr = (float16 *)ptrs->pointers[3];
   float16 *dst_ddr = (float16 *)ptrs->pointers[4];
-  const float *params = (const float *)ptrs->pointers[5];
-
-  float epsilon = params[0];
-  int M = (int)params[1];
-  int N = (int)params[2];
+  float epsilon = *(const float *)ptrs->pointers[5];
+  const int N = *(const int32_t *)ptrs->pointers[6];
+  const int total_elems = *(const int32_t *)ptrs->pointers[7];
+  const int total_rows = total_elems / N;
 
   uint32_t threadID = cfg->threadID;
   uint32_t numThreads = cfg->numThreads;
@@ -257,21 +257,21 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
     return *status_vtcm;
   }
 
-  // Each core processes ceil(M / numCores) rows
-  const int rowIters = (M + (int)numCores - 1) / (int)numCores;
+  // Each core processes ceil(total_rows / numCores) rows
+  const int rowIters = (total_rows + (int)numCores - 1) / (int)numCores;
 
   // Prime slot 0 with the first row assigned to this core before entering the
   // loop
   {
-    const int m0 = (int)coreID;
-    const bool valid0 = (m0 < M);
+    const int r0 = (int)coreID;
+    const bool valid0 = (r0 < total_rows);
     if (localThreadID == 0) {
       if (valid0) {
         *status_vtcm = dma_copy_wait(threadID, attn_vtcm[0],
-                                     attn_out_ddr + m0 * N, rowBytes);
+                                     attn_out_ddr + r0 * N, rowBytes);
         if (*status_vtcm == JIT_DEV_STATUS_SUCCESS) {
           *status_vtcm =
-              dma_copy_wait(threadID, x_vtcm[0], x_ddr + m0 * N, rowBytes);
+              dma_copy_wait(threadID, x_vtcm[0], x_ddr + r0 * N, rowBytes);
         }
       } else {
         *status_vtcm = JIT_DEV_STATUS_SUCCESS;
@@ -285,16 +285,16 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
   }
 
   for (int iter = 0; iter < rowIters; ++iter) {
-    const int m = iter * (int)numCores + (int)coreID;
-    const int m_next = (iter + 1) * (int)numCores + (int)coreID;
-    const bool validRow = (m < M);
-    const bool validNextRow = (m_next < M);
+    const int r      = iter * (int)numCores + (int)coreID;
+    const int r_next = (iter + 1) * (int)numCores + (int)coreID;
+    const bool validRow     = (r      < total_rows);
+    const bool validNextRow = (r_next < total_rows);
     // Ping-pong between slot 0 and 1 each iteration
     const int cur_slot = iter & 1;
     const int next_slot = cur_slot ^ 1;
 
-    float16 *row_dst_ddr = validRow ? (dst_ddr + m * N) : dst_ddr;
-    float16 *row_out_ddr = validRow ? (out_ddr + m * N) : out_ddr;
+    float16 *row_dst_ddr = validRow ? (dst_ddr + r * N) : dst_ddr;
+    float16 *row_out_ddr = validRow ? (out_ddr + r * N) : out_ddr;
 
     // Thread 0 submits async DMA for the next row while all threads compute the
     // current row. attn prefetch is waited immediately (sequential); x prefetch
@@ -305,7 +305,7 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
         uint32_t dma_status = JIT_DEV_STATUS_SUCCESS;
         QShimUDmaHandle h_attn =
             dma_copy_submit(threadID, attn_vtcm[next_slot],
-                            attn_out_ddr + m_next * N, rowBytes, &dma_status);
+                            attn_out_ddr + r_next * N, rowBytes, &dma_status);
         if (dma_status != JIT_DEV_STATUS_SUCCESS ||
             h_attn == INVALID_UDMA_HANDLE) {
           *status_vtcm = (dma_status != JIT_DEV_STATUS_SUCCESS)
@@ -321,7 +321,7 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp(const AicJitEntryPointConfig *cfg,
             // Kick off x DMA and leave it in-flight; save handle for
             // post-compute wait
             QShimUDmaHandle h_x =
-                dma_copy_submit(threadID, x_vtcm[next_slot], x_ddr + m_next * N,
+                dma_copy_submit(threadID, x_vtcm[next_slot], x_ddr + r_next * N,
                                 rowBytes, &dma_status);
             *prefetch_handle_vtcm = (dma_status == JIT_DEV_STATUS_SUCCESS)
                                         ? h_x

--- a/csrc/add_rms_norm/kernel_bf16.cpp
+++ b/csrc/add_rms_norm/kernel_bf16.cpp
@@ -157,11 +157,12 @@ extern "C" void _single_nsp_rms_norm_bf16(
   sync_hvx_threads(threadID, threadsPerCore);
 }
 
-// NSP entry point: drives rms_norm_bf16 row-by-row over an (M, N) matrix.
-// Pointers layout: [0]=attn_out, [1]=x, [2]=weight, [3]=residual_out, [4]=dst,
-// [5]=params{eps,M,N} Each core owns a stripe of rows (coreID, coreID+numCores,
-// ...). Double-buffered DMA (slots 0/1) overlaps prefetch of row m+1 with
-// compute on row m.
+// NSP entry point: drives rms_norm_bf16 row-by-row over a (B, M, N) tensor.
+// Pointers layout: [0]=attn_out, [1]=x, [2]=weight, [3]=residual_out, [4]=dst
+//   [5]=epsilon (float scalar), [6]=B (int scalar), [7]=M (int scalar), [8]=N (int scalar)
+// Each core owns a stripe of rows across all B*M rows.
+// Double-buffered DMA (slots 0/1) overlaps prefetch of row r+1 with
+// compute on row r.
 QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
     const AicJitEntryPointConfig *cfg, const AicJitPointerArray *ptrs) {
   const uint16_t *attn_out_ddr = (const uint16_t *)ptrs->pointers[0];
@@ -169,11 +170,10 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
   const uint16_t *weight_ddr = (const uint16_t *)ptrs->pointers[2];
   uint16_t *out_ddr = (uint16_t *)ptrs->pointers[3];
   uint16_t *dst_ddr = (uint16_t *)ptrs->pointers[4];
-  const float *params = (const float *)ptrs->pointers[5];
-
-  float epsilon = params[0];
-  int M = (int)params[1];
-  int N = (int)params[2];
+  float epsilon = *(const float *)ptrs->pointers[5];
+  const int N = *(const int32_t *)ptrs->pointers[6];
+  const int total_elems = *(const int32_t *)ptrs->pointers[7];
+  const int total_rows = total_elems / N;
 
   uint32_t threadID = cfg->threadID;
   uint32_t numThreads = cfg->numThreads;
@@ -261,21 +261,21 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
     return *status_vtcm;
   }
 
-  // Each core processes ceil(M / numCores) rows
-  const int rowIters = (M + (int)numCores - 1) / (int)numCores;
+  // Each core processes ceil(total_rows / numCores) rows
+  const int rowIters = (total_rows + (int)numCores - 1) / (int)numCores;
 
   // Prime slot 0 with the first row assigned to this core before entering the
   // loop
   {
-    const int m0 = (int)coreID;
-    const bool valid0 = (m0 < M);
+    const int r0 = (int)coreID;
+    const bool valid0 = (r0 < total_rows);
     if (localThreadID == 0) {
       if (valid0) {
         *status_vtcm = dma_copy_wait(threadID, attn_vtcm[0],
-                                     attn_out_ddr + m0 * N, rowBytes);
+                                     attn_out_ddr + r0 * N, rowBytes);
         if (*status_vtcm == JIT_DEV_STATUS_SUCCESS) {
           *status_vtcm =
-              dma_copy_wait(threadID, x_vtcm[0], x_ddr + m0 * N, rowBytes);
+              dma_copy_wait(threadID, x_vtcm[0], x_ddr + r0 * N, rowBytes);
         }
       } else {
         *status_vtcm = JIT_DEV_STATUS_SUCCESS;
@@ -289,15 +289,16 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
   }
 
   for (int iter = 0; iter < rowIters; ++iter) {
-    const int m = iter * (int)numCores + (int)coreID;
-    const int m_next = (iter + 1) * (int)numCores + (int)coreID;
-    const bool validRow = (m < M);
-    const bool validNextRow = (m_next < M);
+    const int r      = iter * (int)numCores + (int)coreID;
+    const int r_next = (iter + 1) * (int)numCores + (int)coreID;
+    const bool validRow     = (r      < total_rows);
+    const bool validNextRow = (r_next < total_rows);
     // Ping-pong between slot 0 and 1 each iteration
     const int cur_slot = iter & 1;
     const int next_slot = cur_slot ^ 1;
 
-    uint16_t *row_dst_ddr = validRow ? (dst_ddr + m * N) : dst_ddr;
+    uint16_t *row_dst_ddr = validRow ? (dst_ddr + r * N) : dst_ddr;
+    uint16_t *row_out_ddr = validRow ? (out_ddr + r * N) : out_ddr;
 
     // Thread 0 submits async DMA for the next row while all threads compute the
     // current row. attn prefetch is waited immediately (sequential); x prefetch
@@ -308,7 +309,7 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
         uint32_t dma_status = JIT_DEV_STATUS_SUCCESS;
         QShimUDmaHandle h_attn =
             dma_copy_submit(threadID, attn_vtcm[next_slot],
-                            attn_out_ddr + m_next * N, rowBytes, &dma_status);
+                            attn_out_ddr + r_next * N, rowBytes, &dma_status);
         if (dma_status != JIT_DEV_STATUS_SUCCESS ||
             h_attn == INVALID_UDMA_HANDLE) {
           *status_vtcm = (dma_status != JIT_DEV_STATUS_SUCCESS)
@@ -324,7 +325,7 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
             // Kick off x DMA and leave it in-flight; save handle for
             // post-compute wait
             QShimUDmaHandle h_x =
-                dma_copy_submit(threadID, x_vtcm[next_slot], x_ddr + m_next * N,
+                dma_copy_submit(threadID, x_vtcm[next_slot], x_ddr + r_next * N,
                                 rowBytes, &dma_status);
             *prefetch_handle_vtcm = (dma_status == JIT_DEV_STATUS_SUCCESS)
                                         ? h_x
@@ -340,11 +341,11 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
     }
 
     if (validRow) {
-      rms_norm_bf16(attn_vtcm[cur_slot], x_vtcm[cur_slot], weight_vtcm,
+      _single_nsp_rms_norm_bf16(attn_vtcm[cur_slot], x_vtcm[cur_slot], weight_vtcm,
                     out_vtcm, dst_vtcm, epsilon, N, threadID, localThreadID,
                     numThreads, partial_sums);
     } else {
-      // Idle row: rms_norm_bf16 contains 3 sync barriers; mirror them to keep
+      // Idle row: _single_nsp_rms_norm_bf16 contains 3 sync barriers; mirror them to keep
       // all threads in lockstep
       sync_hvx_threads(threadID, numThreads);
       sync_hvx_threads(threadID, numThreads);
@@ -363,6 +364,9 @@ QAIC_KERNEL_API uint32_t rms_norm_multi_nsp_bf16(
       }
       if (validRow && *status_vtcm == JIT_DEV_STATUS_SUCCESS) {
         *status_vtcm = dma_copy_wait(threadID, row_dst_ddr, dst_vtcm, rowBytes);
+      }
+      if (validRow && *status_vtcm == JIT_DEV_STATUS_SUCCESS) {
+        *status_vtcm = dma_copy_wait(threadID, row_out_ddr, out_vtcm, rowBytes);
       }
     }
 

--- a/examples/qaic_vision_language.py
+++ b/examples/qaic_vision_language.py
@@ -59,6 +59,11 @@ def run_gemma3(questions: list[str], modality: str) -> ModelRequestData:
         long_prefill_token_threshold=seq_len,
         enable_prefix_caching=False,
         limit_mm_per_prompt={"image": 1},
+        additional_config={
+            "override_qaic_config": {
+                "split_model_io": True,
+            },
+        },
     )
 
     placeholder = "<start_of_image>" if modality == "image" else ""
@@ -68,6 +73,36 @@ def run_gemma3(questions: list[str], modality: str) -> ModelRequestData:
             f"{placeholder}{question}<end_of_turn>\n"
             "<start_of_turn>model\n"
         )
+        for question in questions
+    ]
+
+    return ModelRequestData(
+        engine_args=engine_args,
+        prompts=prompts,
+    )
+
+
+# Gemma 4
+def run_gemma4(questions: list[str], modality: str) -> ModelRequestData:
+    assert modality in ("image", "text")
+
+    engine_args = EngineArgs(
+        model="google/gemma-4-E2B-it",
+        max_model_len=ctx_len,
+        long_prefill_token_threshold=seq_len,
+        enable_prefix_caching=False,
+        limit_mm_per_prompt={"image": 1},
+        additional_config={
+            "override_qaic_config": {
+                "use_onnx_subfunctions": False,
+                "split_model_io": True,
+            },
+        },
+    )
+
+    placeholder = "<|image|>" if modality == "image" else ""
+    prompts = [
+        (f"<bos><|turn>user\n{placeholder}{question}<turn|>\n<|turn>model\n")
         for question in questions
     ]
 
@@ -91,6 +126,11 @@ def run_internvl(questions: list[str], modality: str) -> ModelRequestData:
         enable_prefix_caching=False,
         limit_mm_per_prompt={"image": 1},
         mm_processor_kwargs={"max_dynamic_patch": 12},
+        additional_config={
+            "override_qaic_config": {
+                "split_model_io": True,
+            },
+        },
         # Default is 12; with the thumbnail, it becomes 13 patches.
     )
 
@@ -129,6 +169,11 @@ def run_llava(questions: list[str], modality: str) -> ModelRequestData:
         long_prefill_token_threshold=seq_len,
         enable_prefix_caching=False,
         limit_mm_per_prompt={"image": 1},
+        additional_config={
+            "override_qaic_config": {
+                "split_model_io": True,
+            },
+        },
     )
 
     placeholder = "<image>\n" if modality == "image" else ""
@@ -167,6 +212,7 @@ def run_qwen2_5_vl(questions: list[str], modality: str) -> ModelRequestData:
             "override_qaic_config": {
                 "height": height,
                 "width": width,
+                "split_model_io": True,
             },
         },
     )
@@ -227,6 +273,7 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
             "override_qaic_config": {
                 "height": height,
                 "width": width,
+                "split_model_io": True,
             },
         },
     )
@@ -260,12 +307,67 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
     )
 
 
+# Qwen3.6-VL
+def run_qwen3_6_vl(questions: list[str], modality: str) -> ModelRequestData:
+    assert modality in ("image", "text")
+
+    model_name = "Qwen/Qwen3.6-27B"
+
+    height = [354, 512]
+    width = [536, 910]
+
+    engine_args = EngineArgs(
+        model=model_name,
+        max_model_len=ctx_len,
+        long_prefill_token_threshold=seq_len,
+        enable_prefix_caching=False,
+        mm_processor_kwargs={
+            "min_pixels": 28 * 28,
+            "max_pixels": 1280 * 28 * 28,
+            "fps": 1,
+        },
+        limit_mm_per_prompt={"image": 1},
+        additional_config={
+            "override_qaic_config": {
+                "height": height,
+                "width": width,
+                "use_onnx_subfunctions": True,
+                "split_model_io": True,
+            },
+        },
+    )
+
+    if modality == "image":
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        image_grid_thw = torch.tensor([[-1, -1, -1]])
+    else:
+        placeholder = ""
+        image_grid_thw = None
+
+    prompts = [
+        (
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+            f"<|im_start|>user\n{placeholder}{question}<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        for question in questions
+    ]
+
+    return ModelRequestData(
+        engine_args=engine_args,
+        prompts=prompts,
+        image_grid_thw=image_grid_thw,
+    )
+
+
 model_example_map = {
     "gemma3": run_gemma3,
+    "gemma4": run_gemma4,
     "internvl_chat": run_internvl,
     "llava": run_llava,
     "qwen2_5_vl": run_qwen2_5_vl,
     "qwen3_vl": run_qwen3_vl,
+    "qwen3_6_vl": run_qwen3_6_vl,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -119,33 +119,9 @@ def _is_qaic() -> bool:
 
 
 def get_qaic_sdk_version():
-    """Get the QAIC sdk version from qaicrt.
-
-    Runs in a subprocess so that a SIGABRT from qaicrt (e.g. when the user
-    lacks qaic group membership) does not abort the build process itself.
+    """Get the QAIC sdk version.
     """
-    import platform
-
-    script = (
-        "import sys, platform; "
-        f"sys.path.insert(0, '/opt/qti-aic/dev/lib/{platform.machine()}'); "
-        "from qaicrt import Util as qaic_util; "
-        "_, _, _, patch, _ = qaic_util().getAicVersion(); "
-        "print('.'.join(patch.split('.')[:2]))"
-    )
-    try:
-        import subprocess
-
-        result = subprocess.run(
-            [sys.executable, "-c", script],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        version = result.stdout.strip()
-        return version if version else "1.22"
-    except Exception:
-        return "1.22"
+    return "1.22"
 
 
 def get_requirements(filename=None) -> list[str]:

--- a/vllm_qaic/_custom_ops.py
+++ b/vllm_qaic/_custom_ops.py
@@ -17,7 +17,6 @@ _rms_norm_kernel = _qaic_custom_ops.rms_norm_dispatch
 _NSP_COUNT = current_platform.get_num_cores()
 _THREAD_COUNT = current_platform.get_num_hvx_threads()
 
-
 def rms_norm_hexagon(
     attn_out: torch.Tensor,  # previous layer's output (acts as the residual)
     x: torch.Tensor,  # current layer's input
@@ -30,50 +29,22 @@ def rms_norm_hexagon(
       new_residual = attn_out + x   (stored in FP16 by the kernel)
       normed = new_residual / rms(new_residual) * weight
     """
-    orig_shape = attn_out.shape
-    device = attn_out.device
-
-    # The NSP kernel expects a 2D (M, N) layout.
-    # 4D (B, M, H, N) → (B*M, H*N): normalize across the full hidden dim.
-    # 2D/3D          → (-1, last_dim): fold all leading dims into rows.
-    if attn_out.dim() == 4:
-        B, _M, H, _N = orig_shape
-        flat_N = H * _N
-        attn_out_2d = (
-            attn_out.reshape(B * _M, flat_N).to(dtype=attn_out.dtype).contiguous()
-        )
-        x_2d = x.reshape(B * _M, flat_N).to(dtype=attn_out.dtype).contiguous()
-    else:
-        attn_out_2d = (
-            attn_out.reshape(-1, orig_shape[-1]).to(dtype=attn_out.dtype).contiguous()
-        )
-        x_2d = x.reshape(-1, orig_shape[-1]).to(dtype=attn_out.dtype).contiguous()
-
-    weight_cast = weight.to(dtype=attn_out.dtype, device=device).contiguous()
-    M, N = attn_out_2d.shape
-
-    out = torch.zeros_like(
-        attn_out_2d
-    )  # residual scratch (attn_out + x), filled by kernel phase 1
-    dst = torch.zeros_like(attn_out_2d)  # normalized output, filled by kernel phase 2
-
-    params = torch.tensor(
-        [float(epsilon), float(M), float(N), float(attn_out.dtype == torch.bfloat16)],
-        dtype=torch.float32,
-        device=attn_out.device,
-    ).contiguous()
-
+    out = torch.empty_like(attn_out)
+    dst = torch.empty_like(attn_out)
     # Launch grid: [_NSP_COUNT cores, _THREAD_COUNT HVX threads per core]
     _rms_norm_kernel[_NSP_COUNT, _THREAD_COUNT](
-        attn_out_2d,
-        x_2d,
-        weight_cast,
-        out,  # written as residual by the kernel
-        dst,  # written as normed output by the kernel
-        params,
+        attn_out,
+        x,
+        weight,
+        out,      # written as residual by the kernel
+        dst,      # written as normed output by the kernel
+        float(epsilon),
+        attn_out.shape[-1],
+        attn_out.numel(),
+        int(attn_out.dtype == torch.bfloat16),
     )
 
-    return dst.reshape(orig_shape), out.reshape(orig_shape)
+    return dst, out
 
 
 current_platform.import_kernels()

--- a/vllm_qaic/envs.py
+++ b/vllm_qaic/envs.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     VLLM_QAIC_MOS: int | None = None
     VLLM_QAIC_NUM_CORES: int | None = None
     VLLM_QAIC_QPC_PATH: str | None = None
-    VLLM_TORCH_QAIC_BASE_PATH: str | None = None
+    VLLM_TORCH_QAIC_PROFILER_DIR: str | None = None
 
 # --8<-- [start:env-vars-definition]
 qaic_environment_variables: dict[str, Callable[[], Any]] = {
@@ -35,8 +35,8 @@ qaic_environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_QAIC_NUM_CORES", None)
     ),
     "VLLM_QAIC_QPC_PATH": lambda: os.getenv("VLLM_QAIC_QPC_PATH", None),
-    "VLLM_TORCH_QAIC_BASE_PATH": lambda: os.getenv(
-        "VLLM_TORCH_QAIC_BASE_PATH", "/opt/qti-aic/integrations/torch_qaic"
+    "VLLM_TORCH_QAIC_PROFILER_DIR": lambda: os.getenv(
+        "VLLM_TORCH_QAIC_PROFILER_DIR", None
     ),
 }
 environment_variables.update(qaic_environment_variables)

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -84,6 +84,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         super().__init__()
         model_config = vllm_config.model_config
         config = model_config.hf_config
+        additional_config = vllm_config.additional_config or {}
+        override_qaic_config = additional_config.get("override_qaic_config") or {}
 
         pooler_config = vllm_config.model_config.pooler_config
         self._pooler = None
@@ -118,9 +120,6 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             self.is_qaic_pooler = False
             self.normalize = False
             self.softmax = False
-            override_qaic_config = (vllm_config.additional_config or {}).get(
-                "override_qaic_config"
-            ) or {}
             if override_qaic_config.get("pooling_device", None) == "qaic":
                 self.is_qaic_pooler = True
                 self.normalize = bool(override_qaic_config.get("normalize", False))
@@ -138,9 +137,10 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             # For whisper, the prefill sequence length is fixed to 1.
             self.prefill_seq_len = 1
         else:
-            self.prefill_seq_len = (
-                vllm_config.scheduler_config.long_prefill_token_threshold
+            assert "prefill_seq_len" in override_qaic_config, (
+                "Prefill seq_len missing in override_qaic_config"
             )
+            self.prefill_seq_len = int(override_qaic_config["prefill_seq_len"])
 
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
@@ -383,6 +383,13 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             use_async_scheduling=self.use_async_scheduling,
         )
         self.logits_ndim = self.session.get_logits_ndim()
+        # Resolve the logits output dtype directly from the QPC binding so the
+        # host-side logits buffers match exactly (e.g. float16 for mxfp6/mxint8
+        # models, float32 for full-precision ones). Falls back to float32.
+        _logits_info = self.get_io_shape_and_dtype("logits", is_input=False)
+        self.logits_dtype = (
+            np.dtype(_logits_info[1]) if _logits_info is not None else np.float32
+        )
 
         e = time.perf_counter() - s
         logger.info("Successfully loaded QPC in %s secs", e)
@@ -400,12 +407,12 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.prefill_num_logits_buffer = None
         self.prefill_logits = dict(
             logits=np.random.randn(self.prefill_bsz, 1, self.vocab_size).astype(
-                np.float32
+                self.logits_dtype
             )
         )
         self.session.set_buffers(self.prefill_logits)
         self.batch_prefill_logits = np.empty(
-            (self.decode_bsz, self.vocab_size), dtype=np.float32
+            (self.decode_bsz, self.vocab_size), dtype=self.logits_dtype
         )
         self.decode_num_logits_buffer = None
         if self.num_logits_to_keep is not None:
@@ -519,7 +526,7 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         kv_caches: list[list[np.ndarray]],
     ):
         for _, bidx in enumerate(batch_indices):
-            if kv_caches[bidx] and len(kv_caches[bidx]) > 0:
+            if kv_caches[bidx] is not None and len(kv_caches[bidx]) > 0:
                 assert len(self.kv_cache_info) == len(kv_caches[bidx]), (
                     f"KV buffer count mismatch: "
                     f"expected {len(self.kv_cache_info)} buffers, "
@@ -814,14 +821,6 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     pending_exec_count += 1
                     pending_exec_queue.put(exec_obj_idx)
 
-            if (
-                self.config.model_type == "whisper"
-                and mm_kwargs_list
-                and (mm_kwargs := mm_kwargs_list[i])
-            ):
-                for k, v in mm_kwargs.items():
-                    self.decode_batch_inputs[k][i] = v[0]
-
         return
 
     def _run_decode(
@@ -903,22 +902,21 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         )
         output_key = "logits" if self.task in ("score", "classify") else "output"
 
-        # Build output buffer.
-        if self.is_qaic_pooler:
+        # Build output buffer - two cases based on output_key.
+        if output_key == "logits":
             encode_num_logits_buffer: dict = {
-                "output": np.empty((self.decode_bsz, self.hidden_dimension), np.float32)
-            }
-        elif output_key == "logits":
-            encode_num_logits_buffer = {
                 "logits": np.empty(
                     (self.decode_bsz, getattr(self.config, "num_labels", 1)), np.float32
                 )
             }
         else:
+            output_shape = (
+                (self.decode_bsz, self.hidden_dimension)
+                if self.is_qaic_pooler
+                else (self.decode_bsz, encode_seq_len, self.hidden_dimension)
+            )
             encode_num_logits_buffer = {
-                "output": np.empty(
-                    (self.decode_bsz, encode_seq_len, self.hidden_dimension), np.float32
-                ),
+                "output": np.empty(output_shape, np.float32),
                 **{
                     name: np.empty((self.decode_bsz, self.hidden_dimension), np.float32)
                     for name in self.session.output_names
@@ -971,7 +969,7 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         output_array = output[output_key][: len(prefill_cum_sum)]
         output_tensor = torch.tensor(output_array)
 
-        if not self.is_qaic_pooler and not output_key == "logits":
+        if not self.is_qaic_pooler and output_key != "logits":
             hidden_states = torch.cat(
                 [
                     output_tensor[i, : prompt_lens[i]]
@@ -1183,6 +1181,11 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             # added to decode_batch_inputs before this dict was replaced.
             if getattr(self, "default_mm_kwargs", None):
                 self.decode_batch_inputs.update(self.default_mm_kwargs)
+            # Keep decode_batch_inputs_by_k in sync: _run_decode reads from this
+            # map, so it must point at the rebuilt dict that carries the correct
+            # (MRoPE-aware) position_ids / batch_index / mm-kwargs shapes.
+            for _k in self.decode_batch_inputs_by_k:
+                self.decode_batch_inputs_by_k[_k] = self.decode_batch_inputs
         # TODO: Clean up
         # self._input_map_chg_needed = "decoder_input_ids" in self.session.input_names
         # # This is a hack for mapping names to qpc input,
@@ -1226,7 +1229,7 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                             (self.prefill_bsz, 1, self.vocab_size)
                             if self.logits_ndim == 3
                             else (self.prefill_bsz, self.vocab_size),
-                            dtype=np.float32,
+                            dtype=self.logits_dtype,
                         ),
                     }
                     if self.lora_mode:
@@ -1267,15 +1270,17 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     else (self.decode_bsz, self.vocab_size)
                 )
                 self.session.create_output_buffers(
-                    input_kv_buffers, decode_logits_shape, np.float32
+                    input_kv_buffers, decode_logits_shape, self.logits_dtype
                 )
-                # Pre-allocate logits buffer into decode_batch_inputs once so that
-                # _run_decode can reuse it instead of allocating on every decode step.
-                self.session.create_output_buffers(
-                    self.decode_batch_inputs,
-                    decode_logits_shape,
-                    np.float32,
-                )
+                # Pre-allocate logits buffer into every decode_batch_inputs_by_k
+                # entry so _run_decode can reuse it for all K values. The decode
+                # QPC logits binding is float16, so the buffer must match.
+                for _k_buf in self.decode_batch_inputs_by_k.values():
+                    self.session.create_output_buffers(
+                        _k_buf,
+                        decode_logits_shape,
+                        self.logits_dtype,
+                    )
                 # CCL: seed comp_ctx_lengths buffer for the dummy run; _run_decode
                 # overwrites it per step with the selected bucket buffer.
                 if self.comp_ctx_lengths_decode is not None:
@@ -1283,7 +1288,7 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                         self.comp_ctx_lengths_decode[-1], dtype=np.int64
                     )
                 _ = self.session.set_data_for_kv_handoff(
-                    input_kv_buffers,
+                    KvCache_buff,
                     [("batch_index", bidx), ("ctx_start", 0)],
                     self.decode_execObj_idx,
                     self.session.decode_buff_map,
@@ -1347,11 +1352,13 @@ def load_qaic_model(
         assert override_qaic_config.get("pooling_device"), (
             "pooling_device must be provided in override_qaic_config for pooling task"
         )
-        if override_qaic_config.get("pooling_device", None) == "qaic":
-            if override_qaic_config.get("task") not in ("score", "classify"):
-                assert override_qaic_config.get("pooling_method"), (
-                    "pooling_method must be provided in override_qaic_config for qaic pooling task"
-                )
+        if override_qaic_config.get(
+            "pooling_device", None
+        ) == "qaic" and override_qaic_config.get("task") not in ("score", "classify"):
+            assert override_qaic_config.get("pooling_method"), (
+                "pooling_method must be provided in override_qaic_config for qaic"
+                "pooling task"
+            )
 
     # if provided qpc is valid
     if qpc_path and not check_qpc_exists(qpc_path):
@@ -1663,8 +1670,8 @@ def get_hf_model(
         QEFFAutoModel,
         QEFFAutoModelForCausalLM,
         QEFFAutoModelForImageTextToText,
-        QEFFAutoModelForSpeechSeq2Seq,
         QEFFAutoModelForSequenceClassification,
+        QEFFAutoModelForSpeechSeq2Seq,
     )
     from QEfficient.peft.lora import QEffAutoLoraModelForCausalLM
 
@@ -1732,10 +1739,7 @@ def get_hf_model(
             del args["qaic_config"]
     if model_config.runner_type == "pooling" and not model_config.is_multimodal_model:
         _task = (override_qaic_config or {}).get("task", None)
-        if _task in ("score", "classify"):
-            model_type = "seq_classify"
-        else:
-            model_type = "encode"
+        model_type = "seq_classify" if _task in ("score", "classify") else "encode"
         del args["continuous_batching"]
         del args["qaic_config"]
         del args["kv_offload"]
@@ -1840,6 +1844,7 @@ def _get_qaic_compile_config(
         mxint8_en = True
     # Number of kv cache blocks should be same as num_gpu_blocks, if CPL==blk_size
     kv_cache_batch_size = vllm_config.cache_config.num_cpu_blocks
+    additional_config = vllm_config.additional_config or {}
     prefill_only = None
     # prefill_only options
     if vllm_config.kv_transfer_config:
@@ -1847,12 +1852,17 @@ def _get_qaic_compile_config(
         if kv_role in ["kv_producer", "kv_consumer"]:
             prefill_only = kv_role == "kv_producer"
 
-    _device_group = (vllm_config.additional_config or {}).get("device_group")
+    _device_group = additional_config.get("device_group")
+
+    # update default settings with user overrides from additional_config
+    override_qaic_config: dict[str, Any] | None = (
+        vllm_config.additional_config or {}
+    ).get("override_qaic_config")
 
     # Prepare default config
     cfg: dict[str, Any] = {
         "qpc_path": None,
-        "prefill_seq_len": vllm_config.scheduler_config.long_prefill_token_threshold,
+        "prefill_seq_len": 128,
         "ctx_len": vllm_config.model_config.max_model_len,
         "batch_size": 1,
         "full_batch_size": vllm_config.scheduler_config.max_num_seqs,
@@ -1868,10 +1878,6 @@ def _get_qaic_compile_config(
         "prefill_only": prefill_only,
         "compile_only": False,
     }
-    # update default settings with user overrides from additional_config
-    override_qaic_config: dict[str, Any] | None = (
-        vllm_config.additional_config or {}
-    ).get("override_qaic_config")
     cfg.update(_clean_config(override_qaic_config, vllm_config))
     # update through environment variable
     cfg.update(_clean_config(QAIC_DEVICE_CONFIG[speculative_model_type]))
@@ -2002,9 +2008,13 @@ def _get_qaic_compile_config(
                 "Please set `max_num_seqs` (decode batch size) to 1."
             )
             del cfg["full_batch_size"]
-    qaic_config: dict[str, Any] | None = None
+    qaic_config: dict[str, Any] | None = (override_qaic_config or {}).pop(
+        "qaic_config", None
+    )
     if speculative_model_type in ("target", "turbo"):
-        qaic_config = dict(speculative_model_type=speculative_model_type)
+        if qaic_config is None:
+            qaic_config = {}
+        qaic_config["speculative_model_type"] = speculative_model_type
     # On Device Sampling
     if cfg.get("aic_include_sampler") is not None:
         if qaic_config is None:
@@ -2058,6 +2068,9 @@ def _get_qaic_compile_config(
         assert qpc_idx is not None
         qpc_path = qpc_path.split(":")[qpc_idx]
     stages = int(cfg.pop("stages", 1))
+    # pretrained_extra_args is a from_pretrained argument handled in get_hf_model;
+    # it must not be forwarded to qeff_model.compile() or qaic-compile.
+    cfg.pop("pretrained_extra_args", None)
     # "mdp_num_partitions" is needed for new MDP parititoner in QEFF
     if stages != 1 and "mdp_load_partition_config" not in cfg:
         cfg["mdp_num_partitions"] = stages

--- a/vllm_qaic/model_loader/qaic_multimodal.py
+++ b/vllm_qaic/model_loader/qaic_multimodal.py
@@ -110,15 +110,23 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
                 "image_idx_output": np.array([[0]], dtype=np.int64),
             }
             if "mm_token_type_ids" in self.session.input_names:
+                mm_token_type_shape = (
+                    (1, 1)
+                    if self.session.cluster_id == "prefill"
+                    else (self.decode_bsz, 1)
+                )
                 self.default_mm_kwargs["mm_token_type_ids"] = np.zeros(
-                    (1, 1), dtype=np.int64
+                    mm_token_type_shape, dtype=np.int64
                 )
             self.decode_batch_inputs.update(self.default_mm_kwargs)
 
         if self.config.model_type == "whisper":
-            self.default_mm_kwargs = {
-                k: np.empty(v[0], dtype=v[1]) for k, v in self.mm_input_info.items()
-            }
+            self.default_mm_kwargs = {}
+            for k, v in self.mm_input_info.items():
+                if k == "input_features":
+                    _shape = v[0].copy()
+                    _shape[-1] = 1 # Feature vector during decode is 1
+                    self.default_mm_kwargs["input_features"] = np.empty(_shape, dtype=v[1])
             self.decode_batch_inputs.update(self.default_mm_kwargs)
 
     def _to_np(self, t, dtype: np.dtype | None = None) -> np.ndarray | list[np.ndarray]:

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -223,9 +223,7 @@ class QaicPlatform(Platform):
                 ]
 
         # Shorthand used throughout this method
-        override_qaic_config = (additional_config or {}).get(
-            "override_qaic_config"
-        ) or {}
+        override_qaic_config = additional_config.get("override_qaic_config", {})
         # Normalise types in override_qaic_config (e.g. strings from CLI parser)
         # before any downstream code reads from it, mirroring what
         # _get_qaic_compile_config previously did via its local _clean_config.
@@ -236,6 +234,9 @@ class QaicPlatform(Platform):
             override_qaic_config.update(cleaned)
             if additional_config and "override_qaic_config" in additional_config:
                 additional_config["override_qaic_config"].update(cleaned)
+        else:
+            override_qaic_config = {}
+            additional_config["override_qaic_config"] = override_qaic_config
         # a hack for online serving's Async EngineArgs
         if vllm_config.device_config.device_type != cls.device_type:
             vllm_config.device_config.device_type = cls.device_type
@@ -308,12 +309,6 @@ class QaicPlatform(Platform):
                 cache_config.block_size = model_config.max_model_len  # ctx_len
 
         if cls.is_aot:
-            # max_num_batched_tokens.  QAIC's _prepare_qaic_inputs expands each
-            # decode request's token count from 1 → (1 + num_spec_tokens), but the
-            # scheduler counts decode requests as 1 token each when enforcing the
-            # budget.  Setting max_num_batched_tokens to this value simultaneously
-            # gives the scheduler the correct per-step budget AND sizes the buffers
-            # large enough to never overflow after decode expansion.
             if model_config.hf_config.model_type == "whisper":
                 # Whisper is an encoder-decoder model: vLLM disables chunked prefill
                 # and sets long_prefill_token_threshold to 0, so the formula above
@@ -323,9 +318,37 @@ class QaicPlatform(Platform):
                     model_config.hf_config, "max_source_positions", 1500
                 )
             else:
-                scheduler_config.max_num_batched_tokens = (
-                    scheduler_config.max_num_seqs
-                    * scheduler_config.long_prefill_token_threshold
+                __prefill_seq_len = override_qaic_config.get("prefill_seq_len", 0)
+                if not __prefill_seq_len:
+                    if scheduler_config.long_prefill_token_threshold == 0:
+                        __prefill_seq_len = min(128, model_config.max_model_len)
+                    else:
+                        __prefill_seq_len = min(
+                            scheduler_config.long_prefill_token_threshold,
+                            model_config.max_model_len,
+                        )
+                if not scheduler_config.enable_chunked_prefill:
+                    # TODO: long_prefill_token_threshold should not be set when
+                    # chunked prefill is disabled
+                    logger.warning_once(
+                        "Chunked prefill is disabled; chunk size=%d will be used"
+                        " as prefill_seq_len.",
+                        __prefill_seq_len,
+                    )
+                if "override_qaic_config" not in additional_config:
+                    additional_config["override_qaic_config"] = {}
+                additional_config["override_qaic_config"].update(
+                    {"prefill_seq_len": __prefill_seq_len}
+                )
+                # max_num_batched_tokens.  QAIC's _prepare_qaic_inputs expands each
+                # decode request's token count from 1 → (1 + num_spec_tokens), but the
+                # scheduler counts decode requests as 1 token each when enforcing the
+                # budget.  Setting max_num_batched_tokens to this value simultaneously
+                # gives the scheduler the correct per-step budget AND sizes the buffers
+                # large enough to never overflow after decode expansion.
+                scheduler_config.max_num_batched_tokens = min(
+                    scheduler_config.max_num_seqs * __prefill_seq_len,
+                    scheduler_config.max_num_batched_tokens,
                 )
 
         if cls.is_aot:
@@ -403,26 +426,30 @@ class QaicPlatform(Platform):
                     "repetition penalty"
                 )
 
+            if vllm_config.kv_transfer_config.kv_role == "kv_producer":
+                # Monkey patch uniproc_executor to QaicUniProcExecutor
+                import vllm.v1.executor.uniproc_executor as uniproc_executor
+
+                from vllm_qaic.qaic_uniproc_executor import QaicUniProcExecutor
+
+                uniproc_executor.UniProcExecutor = QaicUniProcExecutor
+                stages = int(override_qaic_config.get("stages"))
+                assert (
+                    stages is None
+                    or int(stages) <= 1
+                    or vllm_config.scheduler_config.max_num_seqs <= int(stages)
+                ), (
+                    f"max_num_seqs ({vllm_config.scheduler_config.max_num_seqs})"
+                    f" must be less than or equal to prefill_pipeline_parallel_size"
+                    f" ({stages}) when prefill streaming is enabled"
+                )
+
         if cls.is_aot:
             model_type = model_config.hf_config.model_type
             if model_config.is_multimodal_model and model_type != "whisper":
                 cls._configure_multimodal_model(
                     vllm_config, model_config, scheduler_config, model_type
                 )
-
-        # for vllm-qaic, long_prefill_token_threshold cannot be 0
-        # as the value is needed for prefill_seq_len
-        if not scheduler_config.enable_chunked_prefill:
-            scheduler_config.long_prefill_token_threshold = model_config.max_model_len
-        elif scheduler_config.long_prefill_token_threshold == 0:
-            vllm_config.scheduler_config.long_prefill_token_threshold = min(
-                128, vllm_config.model_config.max_model_len
-            )
-            logger.warning_once(
-                "long_prefill_token_threshold cannot be 0 for vllm-qaic as it is "
-                "required for prefill_seq_len. Setting it to %d.",
-                scheduler_config.long_prefill_token_threshold,
-            )
 
     @classmethod
     def is_pin_memory_available(cls) -> bool:
@@ -470,6 +497,12 @@ class QaicPlatform(Platform):
             "override_qaic_config"
         ) or {}
 
+        # The QAIC backend does not support the multimodal processor cache.
+        # Disable it unconditionally so input processing uses the
+        # request-id/modality/index UUID path (see V1 input_processor).
+        if model_config.multimodal_config is not None:
+            model_config.multimodal_config.mm_processor_cache_gb = 0
+
         is_vision_encoder = (
             model_config.runner_type == "pooling"
             and "skip_vision" not in override_qaic_config
@@ -491,6 +524,11 @@ class QaicPlatform(Platform):
             scheduler_config.max_num_batched_tokens = (
                 scheduler_config.max_num_seqs
                 * scheduler_config.long_prefill_token_threshold
+            )
+            if "override_qaic_config" not in vllm_config.additional_config:
+                additional_config["override_qaic_config"] = {}
+            additional_config["override_qaic_config"].update(
+                {"prefill_seq_len": model_config.max_model_len}
             )
 
         if model_type in DYNAMIC_RESOLUTION_MODELS:

--- a/vllm_qaic/qaic_uniproc_executor.py
+++ b/vllm_qaic/qaic_uniproc_executor.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+from functools import cached_property
+
+from vllm.v1.executor.uniproc_executor import UniProcExecutor
+
+
+class QaicUniProcExecutor(UniProcExecutor):
+    @cached_property
+    def max_concurrent_batches(self) -> int:
+        additional_config = self.vllm_config.additional_config or {}
+        override_qaic_config = additional_config.get("override_qaic_config") or {}
+        stages = int(override_qaic_config.get("stages", 1))
+        if self.scheduler_config.async_scheduling and stages >= 1:
+            return self.scheduler_config.max_num_seqs + 1
+        return 2 if self.scheduler_config.async_scheduling else 1

--- a/vllm_qaic/spec_decode/qaic_draft_model.py
+++ b/vllm_qaic/spec_decode/qaic_draft_model.py
@@ -51,10 +51,16 @@ class QaicDraftModelProposer:
             draft_vllm_config.speculative_config.num_speculative_tokens
         )
         self.decode_bsz = draft_vllm_config.scheduler_config.max_num_seqs
-        self.prefill_seq_len = (
-            draft_vllm_config.scheduler_config.long_prefill_token_threshold
-        )
-        self.max_model_len = draft_vllm_config.model_config.max_model_len
+        _override_qaic_config = {}
+        if "draft_override_qaic_config" in draft_vllm_config.additional_config:
+            _override_qaic_config = draft_vllm_config.additional_config.get(
+                "draft_override_qaic_config", None
+            )
+        elif "override_qaic_config" in draft_vllm_config.additional_config:
+            _override_qaic_config = draft_vllm_config.additional_config.get(
+                "override_qaic_config", None
+            )
+        self.prefill_seq_len = _override_qaic_config.get("prefill_seq_len", 128)
 
     def load_model(self) -> None:
         logger.info(

--- a/vllm_qaic/utils/qaic_utils.py
+++ b/vllm_qaic/utils/qaic_utils.py
@@ -52,13 +52,13 @@ def _clean_config(
                     and key != "mdp_load_partition_config"
                     and key != "aic_pmu_recipe"
                     and key != "mdp_dump_partition_config"
+                    and key != "mdp_compiler_dump_path"
                     and key != "node_precision_info"
                 ):
                     value = str(value).lower()
                 value = str(value).strip()
             # Ignore donot update list
             _ignore_list = [
-                "prefill_seq_len",
                 "ctx_len",
                 "batch_size",
                 "full_batch_size",

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -23,7 +23,6 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
-from vllm import envs
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
@@ -54,6 +53,7 @@ from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu_input_batch import InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm_qaic import envs
 
 try:
     import torch_qaic.profile as qaic_profile
@@ -354,7 +354,7 @@ class QaicModelRunnerPyt(GPUModelRunner):
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         with optional_qaic_profiling(
-            profiling_dir=envs.VLLM_TORCH_PROFILER_DIR,
+            profiling_dir=envs.VLLM_TORCH_QAIC_PROFILER_DIR,
             profiling_wrapper=qaic_profile.ProfileForwardWithSampling,
             model=self.model,  # type: ignore[has-type]
             n_samples=10,
@@ -905,13 +905,17 @@ class QaicModelRunnerAoT(GPUModelRunner):
         yield
 
     def create_logits_np(self, batch_size, vocab_size, num_decode_tokens: int = 1):
+        # Match the QPC logits output binding dtype (float16 for mxfp6/mxint8
+        # models, float32 for full-precision). The read-back hidden_states are
+        # upcast to float32 before sampling in _compute_hidden_states_and_logits.
+        _dtype = getattr(self.model, "logits_dtype", np.float32)  # type: ignore[has-type]
         if num_decode_tokens > 1:
             return np.empty(
-                (batch_size, num_decode_tokens, vocab_size), dtype=np.float32
+                (batch_size, num_decode_tokens, vocab_size), dtype=_dtype
             )
         if self.model.logits_ndim == 3:  # type: ignore[has-type]
-            return np.empty((batch_size, 1, vocab_size), dtype=np.float32)
-        return np.empty((batch_size, vocab_size), dtype=np.float32)
+            return np.empty((batch_size, 1, vocab_size), dtype=_dtype)
+        return np.empty((batch_size, vocab_size), dtype=_dtype)
 
     def complete_all_inf(
         self, pending_prefill_exec_queue: Queue | None, num_decodes: int | None


### PR DESCRIPTION
…kernel ABI

- Require prefill_seq_len from override_qaic_config instead of deriving it from scheduler_config.long_prefill_token_threshold; compute max_num_batched_tokens accordingly in QaicPlatform.
- Resolve logits output dtype from the QPC binding (float16 for mxfp6/mxint8, float32 otherwise) instead of hardcoding float32
- Add QaicUniProcExecutor to size max_concurrent_batches for async scheduling with prefill pipeline stages (kv_producer role).
- Simplify rms_norm_hexagon: pass tensors and scalar args directly to the kernel instead of pre-flattening on host and packing params into a float tensor; fix rms_norm_multi_nsp_bf16 to also write the residual output buffer, which was previously dropped.
- Disable the multimodal processor cache; fix mm_token_type_ids shape for decode, and whisper's decode input_features shape.
- Add split_model_io to vision-language examples and gemma4/qwen3_6_vl demos.
- Misc fixes: kv_caches None check, qaic_config/pretrained_extra_args handling, decode_batch_inputs_by_k sync, envs import, mdp_compiler_dump_path.