### PR TITLE
Fix overly broad permissions in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,6 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: true
@@ -20,6 +15,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v7
@@ -34,6 +31,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Scopes `pages: write` and `id-token: write` to the `deploy` job only, and `contents: read` to the `build` job, instead of granting all three workflow-wide.
- Fixes zizmor findings: `docs.yml:13` and `docs.yml:14` overly broad permissions at the workflow level.

## Test plan
- [x] Ran `pip install -r docs/requirements-docs.txt` and `mkdocs build --config-file docs/mkdocs.yml` locally to confirm the `build` job's steps still succeed (permissions change doesn't affect job steps, only the `GITHUB_TOKEN` scope).
- [x] Verified generated `docs/site/index.html` renders correctly with expected title and page structure.