### PR TITLE
Preparing for Release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/v0.15.0
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please use the following recommended versions to get started quickly:
 
 | vllm-qaic version | vLLM version | Apps SDK version | Branch | Release type | Doc |
 |---|---|---|---|---|---|
-| v0.15.0.dev0 | v0.15.0 | >= 1.22.0 | [main](https://github.com/qualcomm/vllm-qaic/tree/main) | Pre-release | See [QuickStart](#installation) and [Installation Guide](docs/installation.md) for more details |
+| v0.15.0 | v0.15.0 | >= 1.22.0 | [main](https://github.com/qualcomm/vllm-qaic/tree/main) | Pre-release | See [QuickStart](#installation) and [Installation Guide](docs/installation.md) for more details |
 | v0.23.0.dev0 | v0.23.0 | >= 1.22.0 | [v0.23.0](https://github.com/qualcomm/vllm-qaic/tree/v0.23.0) | Active Development | SpD and LoRaX not yet ported |
 
 ## Branches

--- a/docs/docs/community/release_notes.md
+++ b/docs/docs/community/release_notes.md
@@ -39,7 +39,7 @@ execution modes.
 
 | vllm-qaic | vLLM | Apps SDK | QEfficient | torch (AOT) | torch (PYT) |
 |-----------|------|----------|------------|-------------|-------------|
-| v0.15.0.dev0 | v0.15.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.10.0+cpu |
+| v0.15.0 | v0.15.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.10.0+cpu |
 
 ### Known Issues
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -76,7 +76,7 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 | vllm-qaic | vLLM | Apps SDK | QEfficient | torch (AOT) | torch (PYT) |
 |-----------|------|----------|------------|-------------|-------------|
-| v0.15.0.dev0 | v0.15.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.10.0+cpu |
+| v0.15.0 | v0.15.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.10.0+cpu |
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def load_module_from_path(module_name, path):
     return module
 
 
-VERSION = "0.15.0.dev0"
+VERSION = "0.15.0"
 ROOT_DIR = Path(__file__).parent
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Bump `VERSION` in `setup.py` from `0.15.0.dev0` to `0.15.0` for release.
- Update matching version-compatibility table rows in `README.md`, `docs/docs/index.md`, and `docs/docs/community/release_notes.md` from `v0.15.0.dev0` to `v0.15.0`.
- Add `release/v0.15.0` to the docs deploy workflow's trigger branches (`.github/workflows/docs.yml`), alongside `main`.

## Test plan
- [x] Searched repo for other `0.15.0.dev0` / `0.15.0` references to confirm only vllm-qaic package version strings were updated; vLLM version references (pyproject.toml, requirements files, install docs) were left untouched as they track vLLM's own version, not this package's.