### PR TITLE
Paged Attention support for AOT

### DIFF
--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -147,6 +147,16 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
+        self.num_gpu_blocks_per_batch = self.ctx_len // self.prefill_seq_len
+        if vllm_config.cache_config.enable_prefix_caching:
+            self.num_gpu_blocks = (
+                vllm_config.cache_config.num_gpu_blocks_override
+                if vllm_config.cache_config.num_gpu_blocks_override
+                else self.ctx_len // self.prefill_seq_len
+            )
+        else:
+            self.num_gpu_blocks = self.decode_bsz
+        self.paged_attention = bool(vllm_config.cache_config.enable_prefix_caching)
         self.prefill_bsz = 1
         self.lora_mode = bool(vllm_config.lora_config)
         self.last_decode = False
@@ -218,6 +228,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         prefill_is_partial: list[bool] | None = None,
         prefill_cum_sum: np.ndarray | None = None,
         logits: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         num_prompt_tokens_prefill: np.ndarray | None = None,
     ) -> Queue | None:
         if self.is_pooling_model and not self.is_multimodal_model:
@@ -240,6 +252,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     callback,
                     mm_kwargs_list,
                     logits,
+                    block_table,
+                    slot_id,
                     num_prompt_tokens_prefill,
                 )
                 return pending_prefill_exec_queue
@@ -258,6 +272,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                         logits,
                         lora_ids,
                         mm_kwargs_list,
+                        block_table,
+                        slot_id,
                     )
                     return pending_prefill_exec_queue
                 else:
@@ -267,6 +283,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                         batch_indices,
                         logits,
                         lora_ids,
+                        block_table,
+                        slot_id,
                     )
         return None
 
@@ -392,6 +410,14 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.logits_dtype = (
             np.dtype(_logits_info[1]) if _logits_info is not None else np.float32
         )
+
+        if "block_table" in self.session.input_names:
+            self.decode_batch_inputs["block_table"] = np.full(
+                (self.decode_bsz, self.num_gpu_blocks_per_batch), -1, dtype=np.int64
+            )
+            self.decode_batch_inputs["slot_id"] = np.full(
+                (self.decode_bsz,), 0, dtype=np.int64
+            )
 
         e = time.perf_counter() - s
         logger.info("Successfully loaded QPC in %s secs", e)
@@ -569,6 +595,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         callback: Callable | None = None,
         mm_kwargs_list: list[dict] | None = None,
         logits: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         num_prompt_tokens_prefill: np.ndarray | None = None,
     ):
         pending_exec_count = 0  # in-flight executions in current batch
@@ -667,6 +695,18 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     if logits is not None:
                         chunk_inputs["logits"] = logits[index : index + 1]
 
+                if self.paged_attention:
+                    if block_table is not None and slot_id is not None:
+                        req_block_table = block_table[index : index + 1].reshape(
+                            1, self.num_gpu_blocks_per_batch
+                        )
+                        chunk_inputs["block_table"] = req_block_table
+                        req_slot_id = slot_id[index : index + 1]
+                        chunk_inputs["slot_id"] = req_slot_id
+                    else:
+                        chunk_inputs["block_table"] = batch_index
+                        chunk_inputs["slot_id"] = 0
+
                 if pending_exec_count == self.session.prefill_num_execObj:
                     if callback:
                         callback()
@@ -714,6 +754,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         logits: np.ndarray,
         lora_ids: np.ndarray | None = None,
         mm_kwargs_list: list[dict] | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
     ) -> np.ndarray:
         # perform prefill (only prefill_bsz=1 is supported)
         pending_exec_count = 0  # in-flight executions in current batch
@@ -756,6 +798,17 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 chunk_inputs["lora_ids"] = lora_index
             if mm_kwargs_list and (mm_kwargs := mm_kwargs_list[i]):
                 chunk_inputs.update(mm_kwargs)
+            if self.paged_attention:
+                if block_table is not None and slot_id is not None:
+                    req_block_table = block_table[i : i + 1].reshape(
+                        1, self.num_gpu_blocks_per_batch
+                    )
+                    chunk_inputs["block_table"] = req_block_table
+                    req_slot_id = slot_id[i : i + 1]
+                    chunk_inputs["slot_id"] = req_slot_id
+                else:
+                    chunk_inputs["block_table"] = batch_index
+                    chunk_inputs["slot_id"] = 0
             # chunk the request
             n_chunks: int = iids.shape[-1] // self.prefill_seq_len
 
@@ -832,6 +885,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         batch_indices: np.ndarray,
         logits: np.ndarray,
         lora_ids: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         callback: Callable | None = None,
     ) -> None:
         # Use the per-step K set by QaicModelRunner.  Falls back to max K so
@@ -865,6 +920,21 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             batch_inputs["lora_ids"][:num_decodes] = lora_ids.reshape(num_decodes, 1)
             if num_decodes < self.decode_bsz:
                 batch_inputs["lora_ids"][num_decodes:] = -1
+
+        if self.paged_attention:
+            if block_table is not None and slot_id is not None:
+                self.decode_batch_inputs["block_table"][:num_decodes] = block_table[
+                    :num_decodes
+                ]
+                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[:num_decodes]
+                if num_decodes < self.decode_bsz:
+                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
+                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
+            else:
+                self.decode_batch_inputs["block_table"][:num_decodes] = batch_indices
+                if num_decodes < self.decode_bsz:
+                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
+                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
 
         # For spec-decode target: include num_logits_to_keep in batch_inputs
         # so the hardware knows how many token positions to compute logits for.
@@ -2017,10 +2087,10 @@ def _get_qaic_compile_config(
         if qaic_config is None:
             qaic_config = {}
         qaic_config["speculative_model_type"] = speculative_model_type
+    if qaic_config is None:
+        qaic_config = dict()
     # On Device Sampling
     if cfg.get("aic_include_sampler") is not None:
-        if qaic_config is None:
-            qaic_config = dict()
         qaic_config["include_sampler"] = cfg["aic_include_sampler"]
         if cfg.get("aic_return_pdfs") is not None:
             qaic_config["return_pdfs"] = cfg["aic_return_pdfs"]
@@ -2051,8 +2121,6 @@ def _get_qaic_compile_config(
         or len(cfg.get("comp_ctx_lengths_prefill", [])) > 0
         or len(cfg.get("comp_ctx_lengths_decode", [])) > 0
     ):
-        if qaic_config is None:
-            qaic_config = dict()
         qaic_config["ccl_enabled"] = True
         if not cfg.pop("ccl_enabled", False):
             cfg["comp_ctx_lengths_prefill"] = (
@@ -2065,6 +2133,22 @@ def _get_qaic_compile_config(
                 if (len(cfg.get("comp_ctx_lengths_decode", [])) == 0)
                 else cfg.get("comp_ctx_lengths_decode")
             )
+    # Add num_kv_blocks through qaic_config
+    logger.info(
+        "Num KV Blocks: %s",
+        vllm_config.model_config.max_model_len
+        // vllm_config.scheduler_config.long_prefill_token_threshold,
+    )
+    if vllm_config.cache_config.enable_prefix_caching:
+        qaic_config["num_kv_blocks"] = (
+            vllm_config.model_config.max_model_len
+            // vllm_config.scheduler_config.long_prefill_token_threshold
+        )
+        qaic_config["blocking_mode"] = "kv_paged"
+        qaic_config["enable_blocking"] = True
+    else:
+        qaic_config["blocking_mode"] = ""
+        qaic_config["enable_blocking"] = False
     qpc_path = cfg.pop("qpc_path")
     if qpc_path and kv_offload and len(qpc_path.split(":")) > 1:
         assert qpc_idx is not None

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -926,7 +926,9 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 self.decode_batch_inputs["block_table"][:num_decodes] = block_table[
                     :num_decodes
                 ]
-                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[:num_decodes]
+                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[
+                    :num_decodes
+                ]
                 if num_decodes < self.decode_bsz:
                     self.decode_batch_inputs["block_table"][num_decodes:] = -1
                     self.decode_batch_inputs["slot_id"][num_decodes:] = 0

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -301,16 +301,25 @@ class QaicPlatform(Platform):
                 cache_config.block_size = 16
             else:
                 if cache_config.enable_prefix_caching:
-                    cache_config.enable_prefix_caching = False
                     cache_config.mamba_block_size = (
                         model_config.max_model_len
                     )  # reset to "no-op" default
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
-                    logger.warning_once(
-                        "Prefix caching is not yet supported on v1 Engine. "
-                        "Will automatically disable it."
+                    cache_config.block_size = (
+                        scheduler_config.long_prefill_token_threshold
                     )
-                cache_config.block_size = model_config.max_model_len  # ctx_len
+                elif model_config.is_multimodal_model and model_config.is_encoder_decoder:
+                    cache_config.block_size = 100000
+                else:
+                    cache_config.block_size = model_config.max_model_len  # ctx_len
+
+        # disable async scheduling since Qaic does not yet support it
+        if scheduler_config.async_scheduling:
+            logger.warning(
+                "QAIC currently does not support async scheduling; "
+                "Falling back to non-async scheduling."
+            )
+            scheduler_config.async_scheduling = False
 
         if cls.is_aot:
             if model_config.hf_config.model_type == "whisper":
@@ -539,6 +548,9 @@ class QaicPlatform(Platform):
                 scheduler_config.max_num_seqs
                 * scheduler_config.long_prefill_token_threshold
             )
+            cache_config = vllm_config.cache_config
+            if cache_config and cache_config.enable_prefix_caching:
+                cache_config.block_size = scheduler_config.long_prefill_token_threshold
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -48,8 +48,7 @@ DYNAMIC_RESOLUTION_MODELS = [
 class QaicPlatform(Platform):
     _enum = PlatformEnum.OOT
     primary_attn_backend_cls = (
-        "vllm_qaic.attention.backends"
-        ".qaic_attn.QAicTorchAttentionBackend"
+        "vllm_qaic.attention.backends.qaic_attn.QAicTorchAttentionBackend"
     )
     device_name: str = "qaic"
     # Set device type to cpu if it's AOT.
@@ -308,7 +307,9 @@ class QaicPlatform(Platform):
                     cache_config.block_size = (
                         scheduler_config.long_prefill_token_threshold
                     )
-                elif model_config.is_multimodal_model and model_config.is_encoder_decoder:
+                elif (
+                    model_config.is_multimodal_model and model_config.is_encoder_decoder
+                ):
                     cache_config.block_size = 100000
                 else:
                     cache_config.block_size = model_config.max_model_len  # ctx_len

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -29,7 +29,6 @@ from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm_qaic.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, SupportedTask
 from vllm.utils.import_utils import PlaceholderModule
@@ -206,7 +205,7 @@ class QaicAsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             sampler_output = mr._make_sampler_output(
                 torch.zeros((len(self._input_batch_req_ids), 1), dtype=torch.int64)
             )
-            # 3. Discard samped tokens for partial prefills
+            # 3. Discard sampled tokens for partial prefills
             kv_connector_output = self._kv_connector_output
             discard_sampled_tokens_req_indices = np.nonzero(
                 state.discard_request_mask_np
@@ -624,22 +623,22 @@ class QaicModelRunnerAoT(GPUModelRunner):
                 prev_draft_token_indices.extend(range(start, start + draft_len))
                 indices_match &= prev_index == flattened_index
                 max_flattened_index = max(max_flattened_index, flattened_index)
-        num_commmon_tokens = len(sample_flattened_indices)
-        if num_commmon_tokens == 0:
+        num_common_tokens = len(sample_flattened_indices)
+        if num_common_tokens == 0:
             # No requests in common with the previous iteration
             # So input_ids.cpu will have all the input ids.
             return
-        if indices_match and max_flattened_index == (num_commmon_tokens - 1):
+        if indices_match and max_flattened_index == (num_common_tokens - 1):
             # Common-case optimization: the batch is unchanged
             # and no reordering happened.
             # The indices are both the same permutation of 0..N-1 so
             # we can copy directly using a single slice.
-            self.input_ids.cpu[:num_commmon_tokens].copy_(
-                prev_sampled_token_ids[:num_commmon_tokens, 0],
+            self.input_ids.cpu[:num_common_tokens].copy_(
+                prev_sampled_token_ids[:num_common_tokens, 0],
                 non_blocking=True,
             )
             if self.enable_prompt_embeds:
-                self.is_token_ids.cpu[:num_commmon_tokens] = True
+                self.is_token_ids.cpu[:num_common_tokens] = True
             return
         # Upload the index tensors asynchronously so the scatter can be non-blocking.
         sampled_tokens_index_tensor = torch.tensor(
@@ -690,6 +689,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
         if spec_tokens and any(len(v) > 0 for v in spec_tokens.values()):
             return self.decode_ks[-1]  # proposals exist → full SpD kernel
         return 0  # no proposals → cheap fallback kernel
+
     def _pool(
         self,
         hidden_states: torch.Tensor,
@@ -738,7 +738,9 @@ class QaicModelRunnerAoT(GPUModelRunner):
         finished_mask_qaicpooler = [
             seq_len == prompt_len
             for seq_len, prompt_len in zip(
-                seq_lens_qaicpooler, pooling_metadata_qaicpooler.prompt_lens
+                seq_lens_qaicpooler,
+                pooling_metadata_qaicpooler.prompt_lens,
+                strict=False,
             )
         ]
 
@@ -962,9 +964,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
         # upcast to float32 before sampling in _compute_hidden_states_and_logits.
         _dtype = getattr(self.model, "logits_dtype", np.float32)  # type: ignore[has-type]
         if num_decode_tokens > 1:
-            return np.empty(
-                (batch_size, num_decode_tokens, vocab_size), dtype=_dtype
-            )
+            return np.empty((batch_size, num_decode_tokens, vocab_size), dtype=_dtype)
         if self.model.logits_ndim == 3:  # type: ignore[has-type]
             return np.empty((batch_size, 1, vocab_size), dtype=_dtype)
         return np.empty((batch_size, vocab_size), dtype=_dtype)

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -817,6 +817,32 @@ class QaicModelRunnerAoT(GPUModelRunner):
             self.input_batch.block_table[0].get_numpy_array()[:num_reqs, 0] - 1
         )
 
+        if self.model.paged_attention:
+            # Compute block_table and slot_mapping from vLLM's block management
+            # block_table: (num_reqs, max_num_blocks_per_req)
+            self.block_table = (
+                self.input_batch.block_table[0].get_numpy_array()[:num_reqs].copy() - 1
+            )
+            block_size = self.cache_config.block_size
+            # Compute slot_mapping via compute_slot_mapping
+            # vLLM v0.23's expects (num_reqs, query_start_loc, positions) signature.
+            query_start_loc_np = np.concatenate(([0], cu_num_tokens[:num_reqs])).astype(
+                np.int32
+            )
+            self.input_batch.block_table.compute_slot_mapping(
+                num_reqs,
+                torch.from_numpy(query_start_loc_np),
+                torch.from_numpy(positions_np),
+            )
+            self.slot_mapping = (
+                self.input_batch.block_table[0]
+                .slot_mapping.np[:total_num_scheduled_tokens]
+                .copy()
+            )
+            # Compute per-request slot_id:
+            num_computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            self.slot_id = (num_computed % block_size).astype(np.int64)
+
         torch.add(
             self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
             torch.from_numpy(num_scheduled_tokens),
@@ -1155,6 +1181,11 @@ class QaicModelRunnerAoT(GPUModelRunner):
                 if not self.is_kv_consumer
                 else self.batch_indices[:num_scheduled_tokens]
             )
+            if self.model.paged_attention:
+                decode_block_table: np.ndarray = self.block_table[: self.num_decodes]
+                decode_slot_ids: np.ndarray = self.slot_id[: self.num_decodes]
+            else:
+                decode_block_table, decode_slot_ids = None, None
 
             if self.max_decode_tokens > 1:
                 # mark padded positions as -1 so QAIC hardware ignores them
@@ -1191,6 +1222,15 @@ class QaicModelRunnerAoT(GPUModelRunner):
             discard_request_mask_np = self.discard_request_mask.np[
                 : self.input_batch.num_reqs
             ].copy()
+            if self.model.paged_attention:
+                prefill_block_table: np.ndarray = self.block_table[
+                    self.num_decodes : self.input_batch.num_reqs
+                ]
+                prefill_slot_ids: np.ndarray = self.slot_id[
+                    self.num_decodes : self.input_batch.num_reqs
+                ]
+            else:
+                prefill_block_table, prefill_slot_ids = None, None
 
             # mm_kwargs_list is only needed for prefill requests; skip preprocessing
             # entirely when there are no prefills or the model has no mm inputs.
@@ -1253,6 +1293,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     logits=hidden_states_prefill,
                     kv_caches=self.kv_caches,
                     callback=callback,
+                    block_table=prefill_block_table,
+                    slot_id=prefill_slot_ids,
                     lora_ids=prefill_lora_ids,
                     num_prompt_tokens_prefill=num_prompt_tokens_prefill,
                 )
@@ -1268,6 +1310,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     is_prompt=False,
                     logits=hidden_states_decode,
                     callback=callback,
+                    block_table=decode_block_table,
+                    slot_id=decode_slot_ids,
                     lora_ids=decode_lora_ids,
                 )
 
@@ -1549,6 +1593,15 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     self.vllm_config,
                     self.device,
                 )
+        if self.model.paged_attention:
+            decode_block_table = np.arange(
+                self.model.decode_bsz * self.model.num_gpu_blocks_per_batch,
+                dtype=np.int64,
+            ).reshape(self.model.decode_bsz, self.model.num_gpu_blocks_per_batch)
+            decode_slot_ids = np.zeros(self.model.decode_bsz, dtype=np.int64)
+        else:
+            decode_block_table = None
+            decode_slot_ids = None
         self.kv_cache_info = (
             self.model.kv_cache_info if self.model.disagg_serving_en else None
         )
@@ -1596,6 +1649,14 @@ class QaicModelRunnerAoT(GPUModelRunner):
         else:
             decode_positions = np.array([0] * decode_num_tokens, dtype=np.int64)
         decode_block_ids = np.arange(decode_bsz, dtype=np.int64)
+        if self.model.paged_attention:
+            decode_block_table = np.arange(
+                decode_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
+            ).reshape(decode_bsz, self.model.num_gpu_blocks_per_batch)
+            decode_slot_ids = np.zeros(decode_bsz, dtype=np.int64)
+        else:
+            decode_block_table = None
+            decode_slot_ids = None
         decode_lora_ids = None
         if self.lora_config:
             decode_lora_ids = np.arange(decode_bsz, dtype=np.int64)
@@ -1615,6 +1676,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
             is_prompt=False,
             logits=decode_logits,
             mm_kwargs_list=decode_mm_kwargs_list,
+            block_table=decode_block_table,
+            slot_id=decode_slot_ids,
         )
 
         # Prefill
@@ -1633,6 +1696,14 @@ class QaicModelRunnerAoT(GPUModelRunner):
         prefill_cum_sum = np.array(
             [prefill_seq_len] * prefill_bsz, dtype=np.int64
         ).cumsum()
+        if self.model.paged_attention:
+            prefill_block_table = np.arange(
+                prefill_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
+            ).reshape(prefill_bsz, self.model.num_gpu_blocks_per_batch)
+            prefill_slot_ids = np.zeros(prefill_bsz, dtype=np.int64)
+        else:
+            prefill_block_table = None
+            prefill_slot_ids = None
         prefill_lora_ids = None
         if self.lora_config:
             prefill_lora_ids = np.arange(prefill_bsz, dtype=np.int64)
@@ -1650,6 +1721,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
             prefill_cum_sum=prefill_cum_sum,
             mm_kwargs_list=mm_kwargs_list,
             logits=prefill_logits,
+            block_table=prefill_block_table,
+            slot_id=prefill_slot_ids,
         )
 
         if self.use_async_scheduling:

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -618,13 +618,40 @@ class QaicWorkerAoT(QaicWorker):
         self.cache_config.sliding_window = None
 
         assert num_cpu_blocks == 0
+        if self.model_config.enforce_eager:
+            # adapted from gpu_worker.py
+            self.cache_config.num_gpu_blocks = num_gpu_blocks
+            return
+
         if not self.cache_config.enable_prefix_caching:
             self.cache_config.num_gpu_blocks = num_gpu_blocks
             # Sanity check: AOT requires exact block count; eager is flexible
-            assert num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
+            assert (
+                self.model_config.enforce_eager
+                or num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
+            )
             return
-        else:
-            raise NotImplementedError("prefix caching is not supported on QAIC in V1")
+        elif (
+            not self.model_config.enforce_eager
+            and self.cache_config.enable_prefix_caching
+        ):
+            if self.cache_config.num_gpu_blocks_override:
+                self.cache_config.num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * self.cache_config.num_gpu_blocks_override
+                    + 1
+                )
+            else:
+                # For prefix caching, we need to calculate the number of GPU blocks
+                # based on the max model length and block size.
+                self.cache_config.num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * (
+                        self.model_config.max_model_len
+                        // self.scheduler_config.long_prefill_token_threshold
+                    )
+                    + 1
+                )
 
     def init_device(self):
         """Initialize qaic device
@@ -684,11 +711,24 @@ class QaicWorkerAoT(QaicWorker):
         pass
 
     def determine_available_memory(self) -> int:
-        num_gpu_blocks = (
-            self.cache_config.num_gpu_blocks_override
-            if self.cache_config.num_gpu_blocks_override
-            else self.scheduler_config.max_num_seqs
-        ) + 1
+        if self.vllm_config.cache_config.enable_prefix_caching:
+            if self.cache_config.num_gpu_blocks_override:
+                num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * self.cache_config.num_gpu_blocks_override
+                    + 1
+                )
+            else:
+                num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * (
+                        self.vllm_config.model_config.max_model_len
+                        // self.scheduler_config.long_prefill_token_threshold
+                    )
+                    + 1
+                )
+        else:
+            num_gpu_blocks = self.scheduler_config.max_num_seqs + 1
         # adapted from get_uniform_page_size
         page_sizes = set(
             layer.page_size_bytes for layer in self.get_kv_cache_spec().values()


### PR DESCRIPTION
Summary

This PR adds paged (block-based) KV cache support to the QAIC AOT execution path, which enables prefix caching on vLLM v1.

Until now, AOT allocated one contiguous KV region per sequence, sized to the full context length. That meant:

Prefix caching was explicitly unsupported and raised NotImplementedError.
KV memory scaled with max_num_seqs × max_model_len.
Shared prompt prefixes were recomputed on every request.

With paged attention, KV cache is carved into fixed-size blocks managed by vLLM's block manager and addressed on-device through a per-request block table. Requests only occupy the blocks they need, and identical prefixes can be reused across requests.

Configuration
Paged Attention can be enabled by setting --enable-prefix-caching=True. When enabled, the model is compiled in paged mode and KV blocks are sized to the prefill chunk length. When disabled, the existing single-block-per-sequence path is used.
Block count is derived automatically from the model's context length and prefill chunk size, and can be tuned with --num-gpu-blocks-override.

Limitations
Currently, KV block size is tied to long_prefill_token_threshold; it is not independently configurable.