### PR TITLE
Fix vision-encoder pooler override being silently ignored

### DIFF
--- a/vllm_qaic/model_loader/qaic_multimodal.py
+++ b/vllm_qaic/model_loader/qaic_multimodal.py
@@ -66,7 +66,7 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
 
             # TODO: need to update if we can support reranker
             # TODO: Add additional args for vision embedding models
-            self.pooler = VisionEncoderPooler()
+            self._pooler = VisionEncoderPooler()
 
         self.default_mm_kwargs: dict[str, np.ndarray] | None = None
         self.video_pruning_rate: float | None = getattr(


### PR DESCRIPTION
## Problem
Multimodal encode servers rejected valid `embed` requests with HTTP 400:

```sh
ValueError: Try switching the model's pooling_task via --pooler-config.task embed.
```

## Root cause
`QaicMultiModal.__init__` overrode the pooler with `self.pooler = VisionEncoderPooler()`, but `pooler` is a read-only `@property` on `QaicCausalLM`. Since `VisionEncoderPooler` is an `nn.Module`, `nn.Module.__setattr__` stored it under `_modules["pooler"]` instead of raising, so the property still returned the base `DispatchPooler` and the override was silently dropped.

This stayed hidden until `embed&token_classify` was added to the `DispatchPooler` in PR #51. It outranks `embed` in upstream's task priority list, so the server resolved its pooling task to `embed&token_classify` and no longer matched `embed` requests.

## Fix
Assign the correct field so the override actually applies:

```python
self._pooler = VisionEncoderPooler()
```

Multimodal encoders now report `{"embed"}` and resolve to embed as intended.

## Testing

Qwen2.5-VL-32B disaggregated EPD: encode server reports Supported tasks: ['embed'] and requests succeed; the 400 is gone. Non-multimodal pooling paths are untouched.
