### PR TITLE
[v0.23.0][Enhancement] Add __main__ guard to qaic_eager_mode example

### DIFF
--- a/examples/qaic_eager_mode.py
+++ b/examples/qaic_eager_mode.py
@@ -32,30 +32,36 @@ os.environ["QAIC_VISIBLE_DEVICES"] = (
     "0"  # for multiple devices, separate them through comma, i.e. 0,1,2,3
 )
 
-# Create a LLM.
-llm = LLM(
-    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-    max_num_seqs=decode_bsz,  # determines decode batch size
-    max_model_len=ctx_len,  # ctx_len (does not account for padding,
-    # but does account for prompt and generated tokens)
-    enable_prefix_caching=False,
-    gpu_memory_utilization=0.9,
-    enforce_eager=True,
-    async_scheduling=False,
-    long_prefill_token_threshold=seq_len,
-    tensor_parallel_size=1,
-    # buffers
-)
-# Generate texts from the prompts. The output is a list of RequestOutput objects
-# that contain the prompt, generated text, and other information.
-outputs = llm.generate(prompts, sampling_params)
-# Print the outputs.
-for output in outputs:
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-    generated_tokens = output.outputs[0].token_ids
-    num_generated_tokens = len(generated_tokens)
-    print(
-        f"Prompt: {prompt!r}, Generated text: {generated_text!r},\
-         Num generated tokens: {num_generated_tokens!r}"
+
+def main():
+    # Create a LLM.
+    llm = LLM(
+        model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        max_num_seqs=decode_bsz,  # determines decode batch size
+        max_model_len=ctx_len,  # ctx_len (does not account for padding,
+        # but does account for prompt and generated tokens)
+        enable_prefix_caching=False,
+        gpu_memory_utilization=0.9,
+        enforce_eager=True,
+        async_scheduling=False,
+        long_prefill_token_threshold=seq_len,
+        tensor_parallel_size=1,
+        # buffers
     )
+    # Generate texts from the prompts. The output is a list of RequestOutput
+    # objects that contain the prompt, generated text, and other information.
+    outputs = llm.generate(prompts, sampling_params)
+    # Print the outputs.
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        generated_tokens = output.outputs[0].token_ids
+        num_generated_tokens = len(generated_tokens)
+        print(
+            f"Prompt: {prompt!r}, Generated text: {generated_text!r},\
+             Num generated tokens: {num_generated_tokens!r}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wrap the inference body of examples/qaic_eager_mode.py in a main() function guarded by:
 if __name__ == "__main__":

1. Previously all engine setup and generation ran at module level. Under the spawn multiprocessing start method, vLLM's engine-core child process re-imports the entry script, which would re-execute LLM() and llm.generate() in the child. The guard prevents this. 
2. Wrapping in main() also scopes llm/outputs as locals so device memory is released on return.

Brings the example in line with the pattern already used by qaic.py, qaic_spd.py, qaic_whisper.py, and the other examples. 
No functional change to the example's behavior.

  
