### PR TITLE
Fix Qwen2.5-VL E-PD crash when batching single- and multi-image requests

### DIFF
--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -272,6 +272,15 @@ class QaicQwen2VLMultiModalDataParser(Qwen2VLMultiModalDataParser):
                 if num_frames == 0:
                     return super()._parse_image_data(data)
 
+                # Single-image encode output keeps the encoder batch dim
+                # ([1, V, hidden]); multi-image arrives flattened ([sum(V),
+                # hidden]). Flatten to 2-D so all items share the same rank,
+                # else MultiModalFlatField._reduce_data crashes when batching
+                # a 3-D item with 2-D items.
+                if image_embeds.ndim == 3:
+                    image_embeds = image_embeds.reshape(-1, image_embeds.shape[-1])
+                    data["image_embeds"] = image_embeds
+
                 # Determine vision size
                 # based on whether embeds are batched per frame or flattened.
                 if image_embeds.shape[0] == num_frames:


### PR DESCRIPTION
 ## Problem

On the decode instance, single-image requests receive `image_embeds` with the encoder batch dim intact (`[1, V, hidden]`, 3-D), while multi-image requests arrive flattened (`[sum(V), hidden]`, 2-D). When the scheduler batches a single-image item together with multi-image items, upstream `MultiModalFlatField._reduce_data` hits its variable-length branch on the rank mismatch and the decoder dies:
```sh
  IndexError: tuple index out of range          # inputs.py:576
  RuntimeError: The expanded size of the tensor (N) must match the existing size (5120) ...
```

This surfaced on the multi_resolution benchmark for `Qwen/Qwen2.5-VL-32B-Instruct`, where requests mix resolutions and frame counts (including single-frame).

## Fix
In `QaicQwen2VLMultiModalDataParser._parse_image_data`, flatten 3-D `image_embeds` to 2-D `[-1, hidden]`, so every item has a consistent rank. The reshape is lossless, so there is no accuracy impact.

## Testing
  - multi_resolution benchmark (476 requests, mixed resolutions/frame counts): 476/476 success, no decoder crashes.
  - Re-ran with single-frame (k=1) and empty (k=0) requests included: 476/476 success.