### PR TITLE
Add pre-commit validation workflow for PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,10 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v5
@@ -27,7 +28,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml', 'requirements/lint.txt') }}
           restore-keys: |
             pre-commit-${{ runner.os }}-
 
@@ -37,13 +38,17 @@ jobs:
           pip install -r requirements/lint.txt
 
       - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin "$BASE_REF"
 
       - name: Run pre-commit on changed files
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           pre-commit run \
-            --from-ref origin/${{ github.base_ref }} \
+            --from-ref "origin/$BASE_REF" \
             --to-ref HEAD \
             --show-diff-on-failure \
             --color always

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,49 @@
+name: Pre-commit
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/lint.txt
+
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.base_ref }}
+
+      - name: Run pre-commit on changed files
+        run: |
+          pre-commit run \
+            --from-ref origin/${{ github.base_ref }} \
+            --to-ref HEAD \
+            --show-diff-on-failure \
+            --color always


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to automatically run pre-commit checks on pull requests.

## Changes

- Add `.github/workflows/pre-commit.yml`
- Use Python 3.12
- Install lint dependencies from `requirements/lint.txt`
- Run pre-commit only on files changed by the PR
- Cache pre-commit environments to reduce CI runtime

## Benefits

- Consistent linting and formatting checks in CI
- Faster feedback for contributors
- Reduced manual validation effort