### PR TITLE
Add opt-in support for building vLLM's Rust OpenAI frontend

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,7 +79,7 @@ The script handles all dependency ordering, version pinning, and `uv`/`pip` dete
 
 > **Configuration banner:** Before installation starts, `install.sh` prints a full summary of
 > every version and setting it will use (vllm, vllm-qaic, torch, qeff branch, target device,
-> triton-cpu state). Review it and override any variable before re-running.
+> triton-cpu state, rust frontend state). Review it and override any variable before re-running.
 
 ### AOT mode — `install.sh`
 
@@ -112,9 +112,25 @@ TRITON_CPU=1 TRITON_CPU_SRC=/path/with/more/space/triton-cpu ./scripts/install.s
 # Skip the disk-space pre-flight check entirely
 TRITON_CPU=1 TRITON_CPU_SKIP_DISK_CHECK=1 ./scripts/install.sh aot
 
+# Build vllm's experimental Rust OpenAI-compatible frontend (rust/, build_rust.sh)
+# from source instead of installing vllm from the published git tag. Requires a
+# Rust toolchain (cargo) on PATH — install one via https://rustup.rs, or via
+# conda-forge (`conda install -c conda-forge rust`) into an env already on PATH.
+# Applies to both aot and pyt; clones/reuses a vllm checkout as a sibling of the
+# vllm-qaic repo (`../vllm`) and checks out the pinned VLLM_VERSION tag.
+VLLM_BUILD_RUST=1 ./scripts/install.sh aot
+
 # Force wheel install from a custom SDK path
 VLLM_QAIC_INSTALL_SOURCE=wheel VLLM_QAIC_SDK_PATH=/path/to/sdk ./scripts/install.sh pyt
 ```
+
+**Using the Rust frontend after installing with `VLLM_BUILD_RUST=1`:** it's opt-in at *serve* time too — the standard `vllm serve` entrypoint still runs the Python frontend unless `VLLM_USE_RUST_FRONTEND=1` is set:
+
+```bash
+VLLM_USE_RUST_FRONTEND=1 vllm serve <model> [...same flags as usual...]
+```
+
+> **Status:** this is an experimental, unfinished component of upstream vLLM (not vllm-qaic specific). It does not support every OpenAI-compatible request field yet — e.g. `truncate_prompt_tokens` is rejected outright — and combining `--async-scheduling` with `--long-prefill-token-threshold` has been observed to stall decode almost entirely on QAIC. Test thoroughly before relying on it.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,11 @@
 # Environment overrides:
 #   TRANSFORMERS_VERSION_AOT   If set, pins transformers version after qefficient install
 #   TRANSFORMERS_VERSION_PYT   If set, pins transformers version after torch_qaic install
+#   VLLM_BUILD_RUST            If "1", clones vllm from source and builds its
+#                              experimental Rust OpenAI-compatible frontend
+#                              (rust/, build_rust.sh) before installing, instead
+#                              of installing straight from the git+URL. Requires
+#                              a Rust toolchain (cargo) on PATH — see rustup.rs.
 
 set -euo pipefail
 
@@ -119,10 +124,38 @@ else
     echo "  target device  : ${VLLM_TARGET_DEVICE_PYT}"
 fi
 echo "  --------------------------------------------------------"
+if [ "${VLLM_BUILD_RUST:-0}" = "1" ]; then
+    echo "  rust frontend  : enabled (building from source)"
+else
+    echo "  rust frontend  : disabled  (set VLLM_BUILD_RUST=1 to enable)"
+fi
+echo "  --------------------------------------------------------"
 echo "  Override any variable before running, e.g.:"
 echo "    TRITON_CPU=1 TRITON_CPU_SRC=/data/triton-cpu ./scripts/install.sh aot"
 echo "========================================================"
 echo ""
+
+# Resolve the vllm install target: either the published git tag (default), or
+# a local source checkout with the experimental Rust frontend built in
+# (VLLM_BUILD_RUST=1). Used by both aot and pyt below.
+VLLM_INSTALL_TARGET="vllm @ git+https://github.com/vllm-project/vllm.git@v${VLLM_VERSION}"
+if [ "${VLLM_BUILD_RUST:-0}" = "1" ]; then
+    echo "=== Building vllm Rust frontend (VLLM_BUILD_RUST=1) ==="
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "ERROR: VLLM_BUILD_RUST=1 requires a Rust toolchain (cargo not found on PATH)." >&2
+        echo "       Install one via https://rustup.rs and re-run." >&2
+        exit 1
+    fi
+    VLLM_SRC_DIR="$(dirname "${REPO_ROOT}")/vllm"
+    if [ ! -d "${VLLM_SRC_DIR}/.git" ]; then
+        git clone https://github.com/vllm-project/vllm.git "${VLLM_SRC_DIR}"
+    fi
+    git -C "${VLLM_SRC_DIR}" fetch origin "v${VLLM_VERSION}"
+    git -C "${VLLM_SRC_DIR}" checkout "v${VLLM_VERSION}"
+    bash "${VLLM_SRC_DIR}/build_rust.sh"
+    VLLM_INSTALL_TARGET="${VLLM_SRC_DIR}"
+    echo "INFO: vllm will be installed from ${VLLM_SRC_DIR} (with Rust frontend built)"
+fi
 
 # vllm build deps — always needed for --no-build-isolation
 ${PIP} install "setuptools>=77.0.3,<80.0.0" setuptools-scm setuptools-rust wheel "cmake>=3.26"
@@ -159,7 +192,7 @@ if [ "${MODE}" = "aot" ]; then
     ${PIP} install -r "${SCRIPT_DIR}/../requirements/vllm_dependency_aot.txt"
     VLLM_TARGET_DEVICE="${VLLM_TARGET_DEVICE_AOT}" ${PIP} install \
         --no-build-isolation --no-deps \
-        "vllm @ git+https://github.com/vllm-project/vllm.git@v${VLLM_VERSION}"
+        "${VLLM_INSTALL_TARGET}"
 
     echo "=== Step 3: vllm-qaic-aot ==="
     if [ "${INSTALL_SOURCE}" = "source" ]; then
@@ -205,7 +238,7 @@ elif [ "${MODE}" = "pyt" ]; then
     # and produces no torch Requires-Dist in METADATA so uv will not upgrade torch.
     VLLM_TARGET_DEVICE=${VLLM_TARGET_DEVICE_PYT} ${PIP} install \
         --no-build-isolation --no-deps \
-        "vllm @ git+https://github.com/vllm-project/vllm.git@v${VLLM_VERSION}"
+        "${VLLM_INSTALL_TARGET}"
 
     echo "=== Step 3: vllm-qaic-pyt ==="
     if [ "${INSTALL_SOURCE}" = "source" ]; then


### PR DESCRIPTION
## Summary
- `install.sh` gains `VLLM_BUILD_RUST=1`, mirroring the existing `TRITON_CPU` opt-in pattern: when set, it clones/reuses a vllm source checkout as a sibling of the vllm-qaic repo, checks out the pinned `VLLM_VERSION` tag, runs vllm's `build_rust.sh`, and installs vllm from that local checkout instead of the published git tag so the compiled Rust frontend artifacts (`vllm-rs`) are included. Applies to both `aot` and `pyt` modes.
- `docs/installation.md` documents the new override, how to opt into the Rust frontend at serve time (`VLLM_USE_RUST_FRONTEND=1 vllm serve ...`), and known issues found while testing it against the QAIC backend:
  - Rejects `truncate_prompt_tokens` outright (400 error) — not yet supported by the Rust frontend.
  - `--async-scheduling` combined with `--long-prefill-token-threshold` stalls decode almost entirely on QAIC (observed ~50x throughput regression / requests taking 17+ minutes).

## Test plan
- [x] `bash -n scripts/install.sh` — syntax check passes
- [x] Ran `VLLM_BUILD_RUST=1 ./scripts/install.sh aot` end-to-end in a real AOT venv — cargo build completed, `vllm-rs` binary produced and installed, vllm/vllm-qaic reinstalled from the local checkout successfully
- [x] Verified `VLLM_USE_RUST_FRONTEND=1 vllm serve ...` starts and serves `/v1/completions` and `/v1/chat/completions` on QAIC (TinyLlama-1.1B, AOT mode)
- [x] Benchmarked Rust vs Python frontend throughput/latency on QAIC to confirm the documented caveats are real, reproducible issues (not measurement noise)