### PR TITLE
Enable Triton with QAic Backend

### DIFF
--- a/vllm_qaic/patch/__init__.py
+++ b/vllm_qaic/patch/__init__.py
@@ -71,6 +71,27 @@
 #       Because vLLM defaults to fork-based subprocesses, patching here (in the
 #       main process before fork) is sufficient.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# ** 6. File: patch_qaic_triton_import.py **
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. vllm.triton_utils.HAS_TRITON / triton / tl / tldevice
+#    Why:
+#       Triton is required to run kernels on the QAIC Triton Backend, but
+#       upstream's HAS_TRITON check can end up False even when a usable
+#       Triton install is present (e.g. its Triton-CPU-backend check reads
+#       `importlib.metadata.version("vllm")`, which raises when vllm is
+#       installed under a different distribution name).
+#    How:
+#       Re-import triton and check for QAIC Triton Backend in
+#       triton.backends.backends; if found, re-enable HAS_TRITON and rebind
+#       triton/tl/tldevice on vllm.triton_utils to the real modules.
+#    Note:
+#       Must run before any vllm module does
+#       `from vllm.triton_utils import ...`, since that binds triton/tl/
+#       HAS_TRITON into the importing module's own namespace at that
+#       moment. The patch is applied in QAicPlatform::pre_register_and_update()
+#       after checking that the inference mode is PyT and not AoT.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # =================
 
 import vllm_qaic.patch.patch_config  # noqa

--- a/vllm_qaic/patch/patch_qaic_triton_import.py
+++ b/vllm_qaic/patch/patch_qaic_triton_import.py
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This patch is required for enabling triton with QAIC backend.
+It imports vllm.triton_utils and re-enables HAS_TRITON.
+"""
+
+from vllm import triton_utils
+
+QAIC_TRITON_BACKEND_KEY = "qcom_hexagon_backend"
+
+try:
+    import triton
+    import triton.language as tl
+    import triton.language.extra.libdevice as tldevice
+
+    if QAIC_TRITON_BACKEND_KEY in triton.backends.backends:
+        triton_utils.HAS_TRITON = True
+        triton_utils.triton = triton
+        triton_utils.tl = tl
+        triton_utils.tldevice = tldevice
+except Exception:
+    triton_utils.HAS_TRITON = False

--- a/vllm_qaic/platform.py
+++ b/vllm_qaic/platform.py
@@ -25,6 +25,9 @@ class QaicPlatform(QaicPlatformBase):
         # Adapt the patch here.
         from vllm_qaic import patch  # noqa: F401
 
+        if not cls.is_aot:
+            import vllm_qaic.patch.patch_qaic_triton_import  # noqa
+
         if parser is not None:  # For synchronous vLLM engine
             # disable prefix caching as QAIC backend plugin does not support it
             parser.set_defaults(enable_prefix_caching=False)

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -48,8 +48,7 @@ DYNAMIC_RESOLUTION_MODELS = [
 class QaicPlatform(Platform):
     _enum = PlatformEnum.OOT
     primary_attn_backend_cls = (
-        "vllm_qaic.attention.backends"
-        ".qaic_attn.QAicTorchAttentionBackend"
+        "vllm_qaic.attention.backends.qaic_attn.QAicTorchAttentionBackend"
     )
     device_name: str = "qaic"
     # Set device type to cpu if it's AOT.
@@ -122,18 +121,18 @@ class QaicPlatform(Platform):
     @classmethod
     @functools.cache
     def get_num_cores(cls, device_id: int = 0) -> int:
-        if not cls.is_aot:
-            return torch_qaic.qaic.get_device_info(device_id).num_cores
-        else:
-            pass
+        # Not Implemented for aot
+        if cls.is_aot:
+            raise NotImplementedError
+        return torch_qaic.qaic.get_device_info(device_id).num_cores
 
     @classmethod
     @functools.cache
     def get_num_hvx_threads(cls, device_id: int = 0) -> int:
-        if not cls.is_aot:
-            return torch_qaic.qaic.get_device_info(device_id).per_core_hvx_thread_count
-        else:
-            pass
+        # Not Implemented for aot
+        if cls.is_aot:
+            raise NotImplementedError
+        return torch_qaic.qaic.get_device_info(device_id).per_core_hvx_thread_count
 
     @classmethod
     def check_if_supports_dtype(cls, dtype: torch.dtype):
@@ -285,8 +284,8 @@ class QaicPlatform(Platform):
             )
             if vllm_config.speculative_config:
                 raise ValueError(
-                    "Speculative decoding (SpD) is not supported in eager mode on QAIC. "
-                    "SpD requires AOT (non-eager) compilation."
+                    "Speculative decoding (SpD) is not supported in eager mode "
+                    "on QAIC. SpD requires AOT (non-eager) compilation."
                 )
             if scheduler_config.async_scheduling:
                 logger.warning_once(
@@ -351,7 +350,12 @@ class QaicPlatform(Platform):
                 # gives the scheduler the correct per-step budget AND sizes the buffers
                 # large enough to never overflow after decode expansion.
                 scheduler_config.max_num_batched_tokens = min(
-                    scheduler_config.max_num_seqs * (max(__prefill_seq_len) if isinstance(__prefill_seq_len, (list, tuple)) else __prefill_seq_len),
+                    scheduler_config.max_num_seqs
+                    * (
+                        max(__prefill_seq_len)
+                        if isinstance(__prefill_seq_len, (list, tuple))
+                        else __prefill_seq_len
+                    ),
                     scheduler_config.max_num_batched_tokens,
                 )
             # Reset max_num_scheduled_tokens so that
@@ -566,10 +570,11 @@ class QaicPlatform(Platform):
         """
         Configure multimodal processor settings for models with
         dynamic resolution support. Some vision-language models
-        (e.g. Qwen2.5VL, Qwen3VL) can handle dynamic image resolutions by mapping them to
-        a variable number of visual tokens. On QAIC hardware, the vision encoder requires
-        fixed-size inputs, so this method registers a set of supported ``(height, width)``
-        resolutions that a custom processor will snap images to at runtime.
+        (e.g. Qwen2.5VL, Qwen3VL) can handle dynamic image resolutions by
+        mapping them to a variable number of visual tokens. On QAIC hardware,
+        the vision encoder requires fixed-size inputs, so this method registers
+        a set of supported ``(height, width)`` resolutions that a custom
+        processor will snap images to at runtime.
 
         Currently only Qwen2.5VL and Qwen3VL are supported.
         """


### PR DESCRIPTION
This change patches vLLM's triton support detection in triton_utils in case of PyT mode to allow identifying triton with QAIC as a supported backend.