### PR TITLE
Fix Gemma3 multimodal processing for vLLM 0.23

### DIFF
--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -4,6 +4,7 @@
 # ------------------------------------------------------------------
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # SPDX-License-Identifier: Apache-2.0
+# Adapted from vllm/vllm/model_executor/models/gemma3_mm.py
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -20,6 +21,7 @@ from transformers.image_utils import SizeDict
 from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
 from transformers.models.qwen3_vl import Qwen3VLProcessor
 from transformers.processing_utils import ProcessorMixin
+from transformers.models.gemma3.processing_gemma3 import Gemma3ProcessorKwargs
 from transformers.utils.import_utils import (
     is_torchvision_available,
     is_torchvision_v2_available,
@@ -117,17 +119,20 @@ class QaicGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
         )
 
         processor = self.info.get_hf_processor(**mm_kwargs)
-        images_kwargs = self.info._resolve_image_kwargs(processor, {"do_pan_and_scan"})
-        do_pan_and_scan = images_kwargs["do_pan_and_scan"]
+        images_kwargs = processor._merge_kwargs(
+            Gemma3ProcessorKwargs,
+            tokenizer_init_kwargs=processor.tokenizer.init_kwargs,
+            **self.info.ctx.get_merged_mm_kwargs(mm_kwargs),
+        )["images_kwargs"]
+        do_pan_and_scan = images_kwargs.get(
+            "do_pan_and_scan", processor.image_processor.do_pan_and_scan
+        )
         if do_pan_and_scan:
             raise ValueError("QAIC does not support Gemma3 with pan-and-scan enabled.")
 
         if (images := mm_data.get("images")) is not None:
-            parsed_images = (
-                self._get_data_parser()
-                .parse_mm_data({"image": images})
-                .get_items("image", (ImageEmbeddingItems, ImageProcessorItems))
-            )
+            mm_items = self.info.parse_mm_data({"image": images}, validate=False)
+            parsed_images = mm_items.get_items("image", (ImageEmbeddingItems, ImageProcessorItems))
             num_patches = [1] * len(parsed_images)
             processed_outputs["num_patches"] = torch.tensor(num_patches)
 
@@ -566,7 +571,7 @@ class QaicQwen2_5_VLProcessingInfo(
 
 class _QaicQwenVLMergedEmbedsFieldsMixin:
     """Convert `image_grid_thw` from 3-D to 2-D for Qwen-VL models.
-    
+
     In `qaic_disagg`, `_merge_embeds` adds a leading batch dim to
     `image_grid_thw` ([N, 3] -> [1, N, 3]) and calls `_get_mm_fields_config`
     directly, so `prod(-1)` is 2-D and `flat_from_sizes` raises "size_per_item

--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -8,7 +8,7 @@
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Protocol, cast
 
 import torch
 from packaging.version import Version as _Version
@@ -572,6 +572,14 @@ class QaicQwen2_5_VLProcessingInfo(
         )
 
 
+class _MMFieldsConfigProvider(Protocol):
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]: ...
+
+
 class _QaicQwenVLMergedEmbedsFieldsMixin:
     """Convert `image_grid_thw` from 3-D to 2-D for Qwen-VL models.
 
@@ -603,7 +611,9 @@ class _QaicQwenVLMergedEmbedsFieldsMixin:
                 squeezed[key] = grid.squeeze(0)
         if squeezed is not None:
             hf_inputs = BatchFeature(squeezed)
-        return super()._get_mm_fields_config(hf_inputs, hf_processor_mm_kwargs)
+        return cast(_MMFieldsConfigProvider, super())._get_mm_fields_config(
+            hf_inputs, hf_processor_mm_kwargs
+        )
 
 
 class QaicQwen2_5_VLMultiModalProcessor(

--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -103,6 +103,7 @@ Gemma4ForConditionalGeneration.get_placeholder_str = classmethod(
     )
 )
 
+
 class QaicGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
     def _call_hf_processor(
         self,
@@ -132,7 +133,9 @@ class QaicGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
 
         if (images := mm_data.get("images")) is not None:
             mm_items = self.info.parse_mm_data({"image": images}, validate=False)
-            parsed_images = mm_items.get_items("image", (ImageEmbeddingItems, ImageProcessorItems))
+            parsed_images = mm_items.get_items(
+                "image", (ImageEmbeddingItems, ImageProcessorItems)
+            )
             num_patches = [1] * len(parsed_images)
             processed_outputs["num_patches"] = torch.tensor(num_patches)
 


### PR DESCRIPTION
Fixes Gemma-3 multimodal processing with vLLM 0.23 by replacing the removed _resolve_image_kwargs call with the current HF processor _merge_kwargs flow. The change preserves QAIC behavior by rejecting unsupported pan-and-scan mode and setting one patch per image for Gemma-3 image inputs, including the image-embedding decode path.