### PR TITLE
Rebase vLLM to v0.28.0

### DIFF
--- a/ci_scripts/ci_pipeline_run_plugin.sh
+++ b/ci_scripts/ci_pipeline_run_plugin.sh
@@ -90,24 +90,8 @@ function install_vllm_plugin() {
         mode="$1"
         cd "${VLLM_DIR}"
         ./scripts/install.sh "$mode"
-        #install test dependencies
-        pip3 install anyio
-        pip3 install datasets
-        pip3 install evaluate
-        pip3 install nltk
-        pip3 install pytest
-        pip3 install pytest-asyncio
-        pip3 install pytest-tornasync
-        pip3 install pytest-trio
-        pip3 install pytest-twisted
-        pip3 install rich
-        pip3 install rouge_score
-        pip3 install twisted
-        pip3 install librosa
-        pip3 install soundfile
-        pip3 install tblib
-        pip3 install onnx_ir==0.2.1 # required by layerwise export in qeff main branch
-        pip3 install 'fastapi<0.137'
+        # install test dependencies (single source of truth: requirements/test.txt)
+        pip3 install -r requirements/test.txt
 }
 
 function execute_tests() {

--- a/docs/docs/getting_started/installation/aot_mode.md
+++ b/docs/docs/getting_started/installation/aot_mode.md
@@ -63,7 +63,7 @@ pip install -r requirements/vllm_dependency_aot.txt
 # Build vLLM from source (no C++ compilation needed)
 VLLM_TARGET_DEVICE=empty pip install \
     --no-build-isolation --no-deps \
-    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.15.0"
+    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.28.0"
 
 # 3. vllm-qaic plugin
 TORCH_QAIC_INSTALLED=0 pip install --no-build-isolation ./vllm-qaic
@@ -73,7 +73,7 @@ TORCH_QAIC_INSTALLED=0 pip install --no-build-isolation ./vllm-qaic
 
 | Component | Version |
 |-----------|---------|
-| vLLM | 0.15.0 |
+| vLLM | 0.28.0 |
 | torch | 2.7.0+cpu |
 | QEfficient | main branch |
 | QAIC SDK | >= 1.22.0 |

--- a/docs/docs/getting_started/installation/prerequisites.md
+++ b/docs/docs/getting_started/installation/prerequisites.md
@@ -17,7 +17,7 @@ Qualcomm Cloud AI 100 accelerator with QAIC Platform/Apps SDK >= 1.22.0 on Linux
 | QAIC Platform SDK | >= 1.22.0 | >= 1.22.0 |
 | QAIC Apps SDK | >= 1.22.0 | >= 1.22.0 (with `--install-torch-qaic`) |
 | torch | 2.7.0+cpu | 2.10.0+cpu |
-| vLLM | 0.15.0 | 0.15.0 |
+| vLLM | 0.28.0 | 0.28.0 |
 | QEfficient | main | — |
 
 ## Hardware

--- a/docs/docs/getting_started/installation/pyt_mode.md
+++ b/docs/docs/getting_started/installation/pyt_mode.md
@@ -43,7 +43,7 @@ pip install /opt/qti-aic/integrations/torch_qaic/py312/torch_qaic-*.whl
 pip install -r requirements/vllm_dependency_pyt.txt
 
 # Install vllm-cpu from PyPI (no compilation needed)
-pip install --no-deps "vllm-cpu==0.15.0"
+pip install --no-deps "vllm-cpu==0.28.0"
 
 # 4. vllm-qaic plugin
 pip install --no-build-isolation ./vllm-qaic
@@ -57,7 +57,7 @@ pip install --no-build-isolation ./vllm-qaic
 
 | Component | Version |
 |-----------|---------|
-| vLLM | 0.15.0 (vllm-cpu) |
+| vLLM | 0.28.0 (vllm-cpu) |
 | torch | 2.10.0+cpu |
 | torchvision | 0.25.0+cpu |
 | torch_qaic | 0.1.0 |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -76,7 +76,7 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 | vllm-qaic | vLLM | Apps SDK | QEfficient | torch (AOT) | torch (PYT) |
 |-----------|------|----------|------------|-------------|-------------|
-| v0.15.0.dev0 | v0.15.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.10.0+cpu |
+| v0.28.0.dev0 | v0.28.0 | >= 1.22.0 | main | 2.7.0+cpu | 2.11.0+cpu |
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,7 +152,7 @@ pip install -r requirements/vllm_dependency_aot.txt
 #   (empty target: no C++ compilation, no torch in wheel METADATA)
 VLLM_TARGET_DEVICE=empty pip install \
     --no-build-isolation --no-deps \
-    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.15.0"
+    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.28.0"
 
 # 3. vllm-qaic from source
 TORCH_QAIC_INSTALLED=0 pip install --no-build-isolation ./vllm-qaic
@@ -186,7 +186,7 @@ pip install -r requirements/vllm_dependency_pyt.txt
 #   (no C++ compilation, no torch in wheel METADATA — uv-safe)
 VLLM_TARGET_DEVICE=empty pip install \
     --no-build-isolation --no-deps \
-    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.23.0"
+    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.28.0"
 
 # 3. vllm-qaic from source
 pip install --no-build-isolation ./vllm-qaic
@@ -345,7 +345,7 @@ All version constants are defined in [`scripts/utility.sh`](../scripts/utility.s
 
 | Constant | Value | Description |
 |---|---|---|
-| `VLLM_VERSION` | `0.15.0` | vLLM release tag |
+| `VLLM_VERSION` | `0.28.0` | vLLM release tag |
 | `TORCH_VERSION_AOT` | `2.7.0+cpu` | CPU torch for AOT (matches QEfficient exact pin) |
 | `TORCH_VERSION_PYT` | `2.11.0+cpu` | CPU torch for PYT |
 | `TORCHVISION_VERSION_PYT` | `0.26.0+cpu` | torchvision for PYT (keep in sync with torch) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.23.0" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.28.0" }
 
 [tool.pytest.ini_options]
 markers = [

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
 
-pre-commit==4.0.1
+pre-commit>=4.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
 
-ruff
-isort
 pytest
 anyio
+datasets
 evaluate
 nltk
 pytest-asyncio

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,10 +6,15 @@
 ruff
 isort
 pytest
-
-# type checking
-mypy==1.11.1
-types-PyYAML
-types-regex
-types-requests
-types-setuptools
+anyio
+evaluate
+nltk
+pytest-asyncio
+pytest-tornasync
+pytest-trio
+pytest-twisted
+rich
+rouge_score
+twisted
+tblib
+onnx_ir==0.2.1

--- a/requirements/vllm_dependency_aot.txt
+++ b/requirements/vllm_dependency_aot.txt
@@ -16,38 +16,38 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers == 5.5.4 # required for QEfficient with tag 'r1.21.0'
+transformers >= 5.5.3
+huggingface_hub >= 1.27.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
-fastapi[standard] >= 0.115.0, < 0.137 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint; <0.137 due to prometheus-fastapi-instrumentator#370.
+fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.
+starlette >= 1.0.1 # CVE-2026-48710: Host header injection in < 1.0.1
 aiohttp >= 3.13.3
 openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.12.0
 prometheus_client >= 0.18.0
 pillow  # Required for image processing
-prometheus-fastapi-instrumentator >= 7.0.0
+prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
-llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le"
+llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
 outlines_core == 0.2.14
-# required for outlines backend disk cache
-diskcache == 5.6.3
 lark == 1.2.2
-xgrammar >= 0.2.0, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs
+jsonschema >= 4.23.0 # required for MiniMax M3 tool schema validation
 pyzmq >= 25.0.0
 msgspec
-gguf >= 0.17.0
-mistral_common[image] >= 1.11.3
+mistral_common[image] >= 1.11.6
 opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.15.0 # required for compressed-tensors; vllm v0.23.0 requires 0.17.0, but 0.17.0 pulls torch>=2.10; pinned to 0.15.0 to avoid the torch upgrade
+compressed-tensors == 0.15.0 # required for compressed-tensors; vllm v0.28.0 requires 0.17.0, but 0.17.0 pulls torch>=2.10; pinned to 0.15.0 to avoid the torch upgrade
 depyf==0.20.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files

--- a/requirements/vllm_dependency_pyt.txt
+++ b/requirements/vllm_dependency_pyt.txt
@@ -16,32 +16,32 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers == 5.5.4 # Aligned with AoT and mainline vllm v0.23.0
+transformers >= 5.5.3
+huggingface_hub >= 1.27.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
-fastapi[standard] >= 0.115.0, < 0.137 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint; <0.137 due to prometheus-fastapi-instrumentator#370.
+fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.
+starlette >= 1.0.1 # CVE-2026-48710: Host header injection in < 1.0.1
 aiohttp >= 3.13.3
 openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.12.0
 prometheus_client >= 0.18.0
 pillow  # Required for image processing
-prometheus-fastapi-instrumentator >= 7.0.0
+prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
-llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le"
+llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
 outlines_core == 0.2.14
-# required for outlines backend disk cache
-diskcache == 5.6.3
 lark == 1.2.2
-xgrammar >= 0.2.0, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs
+jsonschema >= 4.23.0 # required for MiniMax M3 tool schema validation
 pyzmq >= 25.0.0
 msgspec
-gguf >= 0.17.0
-mistral_common[image] >= 1.11.3
+mistral_common[image] >= 1.11.6
 opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12

--- a/scripts/utility.sh
+++ b/scripts/utility.sh
@@ -7,7 +7,7 @@
 # Source this file from other scripts: source "$(dirname "$0")/utility.sh"
 
 # === Common ===
-VLLM_VERSION="${VLLM_VERSION:-0.23.0}"
+VLLM_VERSION="${VLLM_VERSION:-0.28.0}"
 VLLM_QAIC_VERSION="${VLLM_QAIC_VERSION:-1.22}"
 
 # === AOT stack ===

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def load_module_from_path(module_name, path):
     return module
 
 
-VERSION = "0.23.0.dev0"
+VERSION = "0.28.0.dev0"
 ROOT_DIR = Path(__file__).parent
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/lora/test_qaic_lora.py
+++ b/tests/e2e/lora/test_qaic_lora.py
@@ -26,8 +26,8 @@ ADAPTER_ID_1 = "jashing/tinyllama-energy-lora"
 
 @pytest.mark.qaic_test_config(
     model_name=BASE_MODEL_NAME,
-    seq_len=64,
-    ctx_len=32,
+    seq_len=32,
+    ctx_len=64,
     decode_bsz=2,
     dtype="mxfp6",
     kv_dtype="mxint8",

--- a/vllm_qaic/__init__.py
+++ b/vllm_qaic/__init__.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 try:
     from vllm_qaic._version import __version__
 except ImportError:
@@ -10,7 +13,30 @@ except ImportError:
 
 
 def _apply_global_platform_patches():
+    _patch_graph_pickler_options()
     _patch_torch_fp4_dtype()
+
+
+# TODO: Remove once torch >= 2.8 is adopted in QAIC envs.
+def _patch_graph_pickler_options() -> None:
+    import torch.fx._graph_pickler as _gp
+
+    if hasattr(_gp, "Options"):
+        return
+
+    @dataclass
+    class Options:
+        ops_filter: Callable[[str], bool] | None = None
+
+    _gp.Options = Options  # type: ignore[attr-defined]
+
+    _original_dumps = _gp.GraphPickler.dumps.__func__  # type: ignore[attr-defined]
+
+    @classmethod  # type: ignore[misc]
+    def _dumps_compat(cls, obj: object, options: Options | None = None) -> bytes:
+        return _original_dumps(cls, obj)
+
+    _gp.GraphPickler.dumps = _dumps_compat  # type: ignore[method-assign]
 
 
 # TODO: Remove once QEFF or torch-qaic is moved to Pytorch >= 2.11.x
@@ -26,6 +52,9 @@ def _patch_torch_fp4_dtype():
 
     if not hasattr(torch, "float4_e2m1fn_x2"):
         torch.float4_e2m1fn_x2 = torch.float32
+
+
+_apply_global_platform_patches()
 
 
 def register():

--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -12,7 +12,7 @@ from typing import Any
 import torch
 from packaging.version import Version as _Version
 from qwen_vl_utils import smart_resize
-from transformers import BatchFeature, Qwen2VLImageProcessorFast, TensorType
+from transformers import BatchFeature, TensorType
 from transformers import __version__ as _transformers_version
 from transformers.image_processing_utils import select_best_resolution
 from transformers.image_transforms import group_images_by_shape, reorder_images
@@ -90,9 +90,15 @@ from vllm.multimodal.processing.processor import (
 )
 
 logger = init_logger(__name__)
+try:
+    from transformers import Qwen2VLImageProcessorFast
+except ImportError:
+    # Transformers >=5.15 removed the Fast suffix class export.
+    from transformers import Qwen2VLImageProcessor as Qwen2VLImageProcessorFast
+
 # transformers v5.5.4 replaced image_processor.min_pixels / .max_pixels class
 # attributes with a size dict keyed by 'shortest_edge' / 'longest_edge'.
-_TRANSFORMERS_NEW_IMAGE_PROCESSOR = _Version(_transformers_version) == _Version("5.5.4")
+_TRANSFORMERS_NEW_IMAGE_PROCESSOR = _Version(_transformers_version) >= _Version("5.5.4")
 _gemma4_get_placeholder_str = Gemma4ForConditionalGeneration.get_placeholder_str
 # Gemma4 with vllm v0.23 wabts image modality instead of image_embeds
 Gemma4ForConditionalGeneration.get_placeholder_str = classmethod(

--- a/vllm_qaic/patch/patch_block_table.py
+++ b/vllm_qaic/patch/patch_block_table.py
@@ -14,7 +14,7 @@ This replaces it with a pure PyTorch/numpy equivalent.
 import numpy as np
 import torch
 import vllm.v1.worker.block_table
-from vllm.v1.worker.block_table import BlockTable, PAD_SLOT_ID
+from vllm.v1.worker.block_table import BlockTable, PAD_SLOT_ID, SlotMappingMode
 
 
 def _qaic_compute_slot_mapping(
@@ -23,6 +23,10 @@ def _qaic_compute_slot_mapping(
     query_start_loc: torch.Tensor,
     positions: torch.Tensor,
 ) -> None:
+    if self.slot_mapping_mode == SlotMappingMode.NONE:
+        return
+    assert self.slot_mapping_mode == SlotMappingMode.TOKEN_TO_KV_SLOT
+
     num_tokens = positions.shape[0]
     query_start_loc_np = query_start_loc.cpu().numpy()
     positions_np = positions.cpu().numpy()

--- a/vllm_qaic/patch/patch_mem_utils.py
+++ b/vllm_qaic/patch/patch_mem_utils.py
@@ -21,9 +21,24 @@ from contextlib import contextmanager
 from typing import Generator
 
 import psutil
+import torch
 import vllm.utils.mem_utils
 from vllm.platforms import current_platform
 from vllm.utils.mem_utils import MemoryProfilingResult, MemorySnapshot
+
+
+def _qaic_post_init(self) -> None:
+    if self.device is None:
+        device_fn = current_platform.current_device
+        if device_fn is not None:
+            self.device_ = torch.device(device_fn())
+        else:
+            self.device_ = torch.device("cpu")
+    else:
+        self.device_ = torch.device(self.device)
+
+    if self.auto_measure:
+        self.measure()
 
 
 def _qaic_measure(self) -> None:
@@ -34,11 +49,22 @@ def _qaic_measure(self) -> None:
     # After `torch.cuda.reset_peak_memory_stats()`,
     # `torch.cuda.memory_reserved()` will keep growing, and only shrink
     # when we call `torch.cuda.empty_cache()` or OOM happens.
-    self.torch_peak = current_platform.memory_stats(device).get(
-        "allocated_bytes.all.peak", 0
-    )
+    memory_stats = current_platform.memory_stats
+    if memory_stats is not None:
+        stats = memory_stats(device)
+        self.torch_peak = stats.get("allocated_bytes.all.peak", 0)
+        self.torch_allocated = stats.get("allocated_bytes.all.current", 0)
+    else:
+        self.torch_peak = 0
+        self.torch_allocated = 0
 
-    self.free_memory, self.total_memory = current_platform.mem_get_info(device)
+    mem_get_info = current_platform.mem_get_info
+    if mem_get_info is not None:
+        self.free_memory, self.total_memory = mem_get_info(device)
+    else:
+        vmem = psutil.virtual_memory()
+        self.free_memory, self.total_memory = vmem.available, vmem.total
+
     shared_sysmem_device_mem_sms = ((8, 7), (11, 0), (12, 1))  # Orin, Thor, Spark
     if (
         current_platform.is_cuda()
@@ -64,7 +90,11 @@ def _qaic_measure(self) -> None:
     # torch.cuda.memory_reserved() is how many bytes
     # PyTorch gets from cuda (by calling cudaMalloc, etc.)
     # this is used to measure the non-torch memory usage
-    self.torch_memory = current_platform.memory_reserved(device)
+    memory_reserved = current_platform.memory_reserved
+    if memory_reserved is not None:
+        self.torch_memory = memory_reserved(device)
+    else:
+        self.torch_memory = 0
 
     self.non_torch_memory = self.cuda_memory - self.torch_memory
     self.timestamp = time.time()
@@ -76,8 +106,13 @@ def _qaic_memory_profiling(
     weights_memory: int = 0,
 ) -> Generator[MemoryProfilingResult, None, None]:
     gc.collect()
-    current_platform.empty_cache()
-    current_platform.reset_peak_memory_stats(baseline_snapshot.device_)
+    empty_cache = current_platform.empty_cache
+    if empty_cache is not None:
+        empty_cache()
+
+    reset_peak_memory_stats = current_platform.reset_peak_memory_stats
+    if reset_peak_memory_stats is not None:
+        reset_peak_memory_stats(baseline_snapshot.device_)
 
     result = MemoryProfilingResult(
         before_create=baseline_snapshot,
@@ -88,7 +123,8 @@ def _qaic_memory_profiling(
     yield result
 
     gc.collect()
-    current_platform.empty_cache()
+    if empty_cache is not None:
+        empty_cache()
     result.after_profile.measure()
 
     diff_profile = result.after_profile - result.before_profile
@@ -104,5 +140,6 @@ def _qaic_memory_profiling(
     )
 
 
+MemorySnapshot.__post_init__ = _qaic_post_init
 MemorySnapshot.measure = _qaic_measure
 vllm.utils.mem_utils.memory_profiling = _qaic_memory_profiling

--- a/vllm_qaic/patch/patch_parallel_state.py
+++ b/vllm_qaic/patch/patch_parallel_state.py
@@ -38,6 +38,7 @@ class QaicGroupCoordinator(GroupCoordinator):
         use_device_communicator: bool,  # whether to use device communicator
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
+        use_all2all: bool = False,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -88,6 +89,7 @@ class QaicGroupCoordinator(GroupCoordinator):
                 device=self.device,
                 device_group=self.device_group,
                 unique_name=self.unique_name,
+                use_all2all=use_all2all,
             )
 
         from vllm.distributed.device_communicators.shm_broadcast import (

--- a/vllm_qaic/patch/patch_rejection_sampler.py
+++ b/vllm_qaic/patch/patch_rejection_sampler.py
@@ -85,11 +85,8 @@ def _qaic_forward(
         sampling_metadata,
     )
     # --- BEGIN QAIC modification: skip-softmax optimisation ---
-    # For greedy decoding argmax(logits) == argmax(softmax(logits)).
-    if sampling_metadata.all_greedy:
-        target_probs = target_logits
-    else:
-        target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    # v0.28.0 rejection_sample() consumes logits and handles internal
+    # greedy fast-path/softmax behavior itself.
     # --- END QAIC modification ---
 
     output_token_ids = rejection_sample(
@@ -98,9 +95,12 @@ def _qaic_forward(
         metadata.max_spec_len,
         metadata.cu_num_draft_tokens,
         draft_probs,
-        target_probs,
+        target_logits,
         bonus_token_ids,
         sampling_metadata,
+        synthetic_mode=self.synthetic_mode,
+        synthetic_conditional_rates=self.synthetic_conditional_rates,
+        use_fp64_gumbel=self.use_fp64_gumbel,
     )
 
     logprobs_tensors = None

--- a/vllm_qaic/patch/patch_rejection_sampler.py
+++ b/vllm_qaic/patch/patch_rejection_sampler.py
@@ -8,19 +8,13 @@
 
 """Monkey-patch for vllm.v1.sample.rejection_sampler.RejectionSampler.
 
-QAIC-specific optimizations in the rejection-sampling forward pass:
+QAIC-specific optimization in the rejection-sampling forward pass:
 
-  1. Skip-clone optimization:
+  Skip-clone optimization:
      When all requests are greedy AND no logprobs are needed, the tensor
      clone before apply_logits_processors is unnecessary because the raw
      logits are never read again.  Skipping the clone avoids a memory
      allocation on the hot path.
-
-  2. Skip-softmax optimization:
-     For greedy decoding argmax(logits) == argmax(softmax(logits)), so
-     computing the probability distribution is unnecessary.  Pass the
-     logits directly as `target_probs` to rejection_sample, which uses
-     target_probs only for argmax when all_greedy=True.
 """
 
 from dataclasses import replace
@@ -43,7 +37,7 @@ def _qaic_forward(
     logits,
     sampling_metadata,
 ) -> SamplerOutput:
-    """Forward pass with QAIC greedy-path optimizations (skip-clone, skip-softmax)."""
+    """Forward pass with QAIC greedy-path skip-clone optimization."""
     assert metadata.max_spec_len <= MAX_SPEC_LEN
 
     bonus_logits_indices = metadata.bonus_logits_indices
@@ -84,10 +78,6 @@ def _qaic_forward(
         metadata.cu_num_draft_tokens,
         sampling_metadata,
     )
-    # --- BEGIN QAIC modification: skip-softmax optimisation ---
-    # v0.28.0 rejection_sample() consumes logits and handles internal
-    # greedy fast-path/softmax behavior itself.
-    # --- END QAIC modification ---
 
     output_token_ids = rejection_sample(
         metadata.draft_token_ids,

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -1901,13 +1901,16 @@ def _torch_cuda_wrapper():
             pass
 
     cuda_event = torch.Event
+    cuda_cuda_event = torch.cuda.Event
     cuda_stream = torch.cuda.Stream
     try:
         torch.Event = _EventPlaceholder
+        torch.cuda.Event = _EventPlaceholder
         torch.cuda.Stream = _StreamPlaceholder
         yield
     finally:
         torch.Event = cuda_event
+        torch.cuda.Event = cuda_cuda_event
         torch.cuda.Stream = cuda_stream
 
 

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -260,6 +260,7 @@ class QaicAsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         # 3. Book keep to update input batch
         (
             num_nans_in_logits,
+            _num_nans_device,
             logprobs_lists,
             valid_sampled_token_ids,
             prompt_logprobs_dict,
@@ -1446,6 +1447,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
 
         (
             num_nans_in_logits,
+            _num_nans_device,
             logprobs_lists,
             valid_sampled_token_ids,
             prompt_logprobs_dict,

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -421,6 +421,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
 
         self.use_cuda_graph = False
         self.cascade_attn_enabled = False
+        self.pin_memory = False
 
         assert device == torch.device("cpu")
         # --- Disaggregated serving flags (must precede drafter gating) ---


### PR DESCRIPTION
  Rebases the QAIC plugin from vLLM v0.23.0 to v0.28.0.

  ### Version bumps

  - `setup.py`, `pyproject.toml`, `scripts/utility.sh`: v0.23.0 → v0.28.0
  - `requirements/vllm_dependency_{aot,pyt}.txt`: aligned with upstream v0.28.0 (transformers, fastapi/starlette, prometheus-fastapi-instrumentator, xgrammar, mistral_common, jsonschema; dropped diskcache/gguf)
  - `requirements/lint.txt`: `pre-commit` → `>=4.5.1`

  ### v0.28.0 API adaptations

  - `patch_parallel_state.py`: add `use_all2all` arg to `QaicGroupCoordinator` (new `GroupCoordinator` param)
  - `worker/model_runner.py`: unpack new `_num_nans_device` from `_bookkeeping_sync`; set `self.pin_memory = False` (upstream moved to module-level `PIN_MEMORY`); patch `torch.cuda.Event` in `_torch_cuda_wrapper`
  - `patch_block_table.py`: handle new `SlotMappingMode` (early-return for `NONE`)
  - `patch_rejection_sampler.py`: pass `synthetic_mode`/`synthetic_conditional_rates`/`use_fp64_gumbel` to `rejection_sample`; drop stale skip-softmax path
  - `patch_mem_utils.py`: capability-guard platform memory hooks + add `MemorySnapshot.__post_init__` override
  - `__init__.py`: apply graph-pickler `Options` shim at import (torch < 2.8 compat)

  ### Transformers 5.15.1 compatibility

  - `qaic_custom_mm_processor.py`: fallback import for `Qwen2VLImageProcessorFast`; widen version gate to
    `>= 5.5.4`

  ### Test / CI

  - `test_qaic_lora.py`: fix swapped `seq_len`/`ctx_len` (violated new `long_prefill_token_threshold ≤ max_model_len` check)
  - `requirements/test.txt`: consolidate test deps (drop linters, add datasets)
  - `ci_pipeline_run_plugin.sh`: install test deps from `requirements/test.txt` (single source of truth)

  ### Validation

  - `examples/qaic.py` runs end-to-end in AOT
  - AOT CI (`ci_fasttest_qaic_aot.sh`) passes