### PR TITLE
Fallback CI: return parser stats, add Fallback? column, e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,9 @@ AGENTS.md
 # Results
 *.csv
 
+# Fallback-ops CI run artifacts (logs/csv/xlsx)
+ci_scripts/ci_logs/
+
 # Python pickle files
 *.pkl
 

--- a/ci_scripts/ci_fallback_ops.sh
+++ b/ci_scripts/ci_fallback_ops.sh
@@ -18,12 +18,20 @@
 #   --tp-size    <N>            Tensor parallel size (default: 4)
 #   --logs-dir   <dir>          Log output directory (default: ./ci_logs)
 #   --models-dir <dir>          Directory containing scraped JSON files
+#   --ref        <git_ref>      vLLM ref whose model list to use, i.e.
+#                               <type>_models_<ref>.json as written by
+#                               scrape_models.py (default: newest found)
+#   --delete-hf-checkpoint      Delete each model's cached HF checkpoint once its
+#                               run finishes, to bound disk use across a sweep
+#                               (default: keep checkpoints)
 #
 # Examples:
 #   bash ci_fallback_ops.sh --type llm --priority P0
 #   bash ci_fallback_ops.sh --type vlm --family qwen --tp-size 4
 #   bash ci_fallback_ops.sh --type llm --model allenai/OLMo-1B-hf
 #   bash ci_fallback_ops.sh --type vlm --model Qwen/Qwen-VL
+#   bash ci_fallback_ops.sh --type llm --delete-hf-checkpoint
+#   bash ci_fallback_ops.sh --type llm --ref v0.23.0
 #
 # To add a new model type (e.g. embedding):
 #   1. Add entry to RUNNER_MAP, JSON_PREFIX, RUNNER_EXTRA_ARGS below
@@ -32,7 +40,7 @@
 ######################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EAGER_DIR=EAGER_DIR="${SCRIPT_DIR}/eager"
+EAGER_DIR="${SCRIPT_DIR}/eager"
 
 # User-configurable defaults
 TYPE="all"
@@ -40,16 +48,20 @@ MODEL=""
 PRIORITY=""
 FAMILY=""
 TP_SIZE="4"
-QAIC_DEBUG="0"
+QAIC_DEBUG="1"
 LOGS_DIR="${PWD}/ci_logs"
 MODELS_DIR="${EAGER_DIR}"
 PRIORITY_CFG="${EAGER_DIR}/priority_config.json"
+# Empty means "auto-discover": pick the newest <type>_models_<ref>.json present.
+REF=""
+# Off by default: a sweep must never evict a checkpoint unless explicitly asked,
+# since the HF cache is usually shared between engineers.
+DELETE_HF_CHECKPOINT="0"
 SLEEP_BETWEEN=10
 
 # QAIC runtime environment
 export QAIC_FORCE_PLATFORM_QCCL=1
 export QAIC_QCCL_ALGO=tree
-export QAIC_DDR_SCRATCH_PAD_IN_MB=2000
 export QAIC_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
 # Auto-detect all available QAIC devices if QAIC_VISIBLE_DEVICES is not already set
@@ -100,6 +112,9 @@ while [[ $# -gt 0 ]]; do
         --tp-size)     TP_SIZE="$2";     shift 2 ;;
         --logs-dir)    LOGS_DIR="$2";    shift 2 ;;
         --models-dir)  MODELS_DIR="$2";  shift 2 ;;
+        --ref)         REF="$2";         shift 2 ;;
+        # Boolean flag: takes no value, so shift 1
+        --delete-hf-checkpoint) DELETE_HF_CHECKPOINT=1; shift ;;
         *) echo "Unknown argument: $1"; exit 1 ;;
     esac
 done
@@ -146,6 +161,65 @@ for m in models:
 PYEOF
 }
 
+# Mirror scrape_models.py's ref_suffix(): a ref may contain '/'
+# (e.g. 'release/1.2'), which is not filename-safe.
+ref_suffix() {
+    echo "${1//\//_}"
+}
+
+# Locate the scraped model list for one type, setting RESOLVED_JSON/RESOLVED_REF.
+# scrape_models.py writes one list per vLLM ref -- <prefix>_<ref>.json, e.g.
+# llm_models_v0.23.0.json -- and several refs can sit side by side in MODELS_DIR,
+# so a bare <prefix>.json lookup finds nothing.
+#   --ref given : use exactly that ref's list, no guessing.
+#   no --ref    : use the newest list found, and say which, because silently
+#                 running a stale model list is worse than being noisy.
+# Returns non-zero (with a message) when the type has no list to run.
+resolve_json() {
+    local model_type="$1"
+    local prefix="${JSON_PREFIX[$model_type]}"
+    RESOLVED_JSON=""
+    RESOLVED_REF=""
+
+    if [ -n "$REF" ]; then
+        local candidate="${MODELS_DIR}/${prefix}_$(ref_suffix "$REF").json"
+        if [ ! -f "$candidate" ]; then
+            echo "Warning: model list not found: ${candidate} — skipping ${model_type}"
+            echo "         create it with: python3 ${EAGER_DIR}/scrape_models.py --ref ${REF} --type ${model_type} --output-dir ${MODELS_DIR}"
+            return 1
+        fi
+        RESOLVED_JSON="$candidate"
+        RESOLVED_REF="$REF"
+        echo "Using ${model_type} list: ${RESOLVED_JSON##*/} (ref ${RESOLVED_REF})"
+        return 0
+    fi
+
+    local -a matches=()
+    local f
+    for f in "${MODELS_DIR}/${prefix}_"*.json; do
+        [ -f "$f" ] && matches+=("$f")
+    done
+
+    if [ ${#matches[@]} -eq 0 ]; then
+        echo "Warning: no ${prefix}_<ref>.json in ${MODELS_DIR} — skipping ${model_type}"
+        echo "         create one with: python3 ${EAGER_DIR}/scrape_models.py --type ${model_type} --output-dir ${MODELS_DIR}"
+        return 1
+    fi
+
+    # -V sorts version-ish names naturally, so v0.23.0 beats v0.9.1
+    RESOLVED_JSON=$(printf '%s\n' "${matches[@]}" | sort -V | tail -1)
+    # <prefix>_<ref>.json -> <ref>
+    local base="${RESOLVED_JSON##*/}"
+    base="${base%.json}"
+    RESOLVED_REF="${base#${prefix}_}"
+
+    if [ ${#matches[@]} -gt 1 ]; then
+        echo "Note: ${#matches[@]} ${prefix} lists in ${MODELS_DIR}: ${matches[*]##*/}"
+    fi
+    echo "Using ${model_type} list: ${RESOLVED_JSON##*/} (ref ${RESOLVED_REF})"
+    return 0
+}
+
 # Run one model
 run_model() {
     local model_type="$1"
@@ -167,10 +241,19 @@ run_model() {
     local logname="${LOGS_DIR}/log_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
     local parse_logname="${LOGS_DIR}/parse_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
 
+    # Both run_llms.py and run_vlms.py expose the same flag name, so a single
+    # array forwards it for every model type. Stays empty (expands to nothing)
+    # unless --delete-hf-checkpoint was passed.
+    local cleanup_flag=()
+    if [ "$DELETE_HF_CHECKPOINT" -eq 1 ]; then
+        cleanup_flag=(--delete-hf-checkpoint)
+    fi
+
     logsave "${logname}" python "${EAGER_DIR}/${runner}" \
         --model-name "${model_name}" \
         --tp-size "${TP_SIZE}" \
-        ${extra_args}
+        ${extra_args} \
+        "${cleanup_flag[@]}"
 
     # Parse the log to extract fallback ops and write to parse log
     log_path="${logname}"
@@ -191,21 +274,32 @@ else
 fi
 
 # Main loop
-# For each type: find its JSON, filter models by priority/family, run each one
+# For each type: find its ref's model list, filter by priority/family, run each one
+# EXCEL_REF is what gets handed to parse_logs_to_excel.py: a single ref when every
+# type resolved to the same one, empty (= merge whatever is found) otherwise.
+EXCEL_REF="$REF"
+EXCEL_REF_SET=0
+
 for model_type in "${TYPES[@]}"; do
 
-    # Single-model mode: bypass JSON entirely and run the given model directly
+    # Single-model mode: bypass the model list entirely and run the given model
     if [ -n "$MODEL" ]; then
         run_model "$model_type" "$MODEL"
         continue
     fi
 
-    json_file="${MODELS_DIR}/${JSON_PREFIX[$model_type]}.json"
+    # Locate <type>_models_<ref>.json; skips this type if it has no list
+    resolve_json "$model_type" || continue
+    json_file="$RESOLVED_JSON"
 
-    # Skip this type if the scraped JSON for the given ref doesn't exist
-    if [ ! -f "$json_file" ]; then
-        echo "Warning: JSON not found: ${json_file} — skipping ${model_type}"
-        continue
+    # Remember the ref actually used, so the Excel step reads the same lists
+    if [ -z "$REF" ] && [ -n "$RESOLVED_REF" ]; then
+        if [ "$EXCEL_REF_SET" -eq 0 ]; then
+            EXCEL_REF="$RESOLVED_REF"
+            EXCEL_REF_SET=1
+        elif [ "$EXCEL_REF" != "$RESOLVED_REF" ]; then
+            EXCEL_REF=""
+        fi
     fi
 
     while IFS= read -r model_name; do
@@ -217,4 +311,5 @@ done
 # Aggregate all parse logs into a per-type Excel sheet once all models are done
 python3 "${EAGER_DIR}/parse_logs_to_excel.py" \
     --log-dir "${LOGS_DIR}" \
-    --models-dir "${MODELS_DIR}"
+    --models-dir "${MODELS_DIR}" \
+    ${EXCEL_REF:+--ref "${EXCEL_REF}"}

--- a/ci_scripts/ci_fallback_ops.sh
+++ b/ci_scripts/ci_fallback_ops.sh
@@ -1,0 +1,220 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+#!/bin/bash
+
+#################### ci_fallback_ops.sh ##############################
+# CI script for collecting fallback ops across model types.
+#
+# Usage:
+#   bash ci_fallback_ops.sh [OPTIONS]
+#
+# Options:
+#   --type       llm|vlm|all    Model type to run (default: all)
+#   --model      <model_id>     Run a single model directly (requires --type llm|vlm)
+#   --priority   P0|P1|P2       Priority tier filter (default: all)
+#   --family     <name>         Run only models matching this family name
+#   --tp-size    <N>            Tensor parallel size (default: 4)
+#   --logs-dir   <dir>          Log output directory (default: ./ci_logs)
+#   --models-dir <dir>          Directory containing scraped JSON files
+#
+# Examples:
+#   bash ci_fallback_ops.sh --type llm --priority P0
+#   bash ci_fallback_ops.sh --type vlm --family qwen --tp-size 4
+#   bash ci_fallback_ops.sh --type llm --model allenai/OLMo-1B-hf
+#   bash ci_fallback_ops.sh --type vlm --model Qwen/Qwen-VL
+#
+# To add a new model type (e.g. embedding):
+#   1. Add entry to RUNNER_MAP, JSON_PREFIX, RUNNER_EXTRA_ARGS below
+#   2. Add run_<type>.py in the eager/ dir
+#   3. Run scrape_models.py with the new type and store its JSON
+######################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EAGER_DIR=EAGER_DIR="${SCRIPT_DIR}/eager"
+
+# User-configurable defaults
+TYPE="all"
+MODEL=""
+PRIORITY=""
+FAMILY=""
+TP_SIZE="4"
+QAIC_DEBUG="0"
+LOGS_DIR="${PWD}/ci_logs"
+MODELS_DIR="${EAGER_DIR}"
+PRIORITY_CFG="${EAGER_DIR}/priority_config.json"
+SLEEP_BETWEEN=10
+
+# QAIC runtime environment
+export QAIC_FORCE_PLATFORM_QCCL=1
+export QAIC_QCCL_ALGO=tree
+export QAIC_DDR_SCRATCH_PAD_IN_MB=2000
+export QAIC_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+# Auto-detect all available QAIC devices if QAIC_VISIBLE_DEVICES is not already set
+# if [ -z "${QAIC_VISIBLE_DEVICES}" ]; then
+#     _devices=$(sudo /opt/qti-aic/tools/qaic-util -q 2>/dev/null \
+#         | grep -oP '^QID \K\d+' \
+#         | sort -n | tr '\n' ',' | sed 's/,$//')
+#     [ -n "$_devices" ] && export QAIC_VISIBLE_DEVICES="$_devices"
+# fi
+
+
+# Model type registry 
+# To support a new model type:
+#   1. Add its name to ALL_TYPES (controls run order for --type all)
+#   2. Add one entry to each of RUNNER_MAP, JSON_PREFIX, RUNNER_EXTRA_ARGS
+#   3. Create the corresponding run_<type>.py in eager/
+ALL_TYPES=("llm" "vlm")
+
+#python scripts
+declare -A RUNNER_MAP=(
+    ["llm"]="run_llms.py"
+    ["vlm"]="run_vlms.py"
+    # ["embedding"]="run_embeddings.py"
+    # ["spd"]="run_spd.py"
+)
+#model list
+declare -A JSON_PREFIX=(
+    ["llm"]="llm_models"
+    ["vlm"]="vlm_models"
+    # ["embedding"]="embedding_models"
+    # ["spd"]="spd_models"
+)
+#extra args for runner script
+declare -A RUNNER_EXTRA_ARGS=(
+    ["llm"]=""
+    ["vlm"]="--model-impl vllm"
+    # ["embedding"]=""
+    # ["spd"]=""
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --type)        TYPE="$2";        shift 2 ;;
+        --model)       MODEL="$2";       shift 2 ;;
+        --priority)    PRIORITY="$2";    shift 2 ;;
+        --family)      FAMILY="$2";      shift 2 ;;
+        --tp-size)     TP_SIZE="$2";     shift 2 ;;
+        --logs-dir)    LOGS_DIR="$2";    shift 2 ;;
+        --models-dir)  MODELS_DIR="$2";  shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+# --model requires a specific type (not "all")
+if [ -n "$MODEL" ] && [ "$TYPE" = "all" ]; then
+    echo "Error: --model requires --type llm|vlm (not 'all')"
+    exit 1
+fi
+
+mkdir -p "${LOGS_DIR}"
+
+# Python helper: filter model list from JSON
+get_models() {
+    local json_file="$1"
+    python3 - "$json_file" "$PRIORITY_CFG" "$PRIORITY" "$FAMILY" << 'PYEOF'
+import json, sys
+
+json_file, priority_cfg_file, priority_filter, family_filter = sys.argv[1:]
+
+with open(json_file) as f:
+    models = json.load(f)
+
+if priority_filter:
+    with open(priority_cfg_file) as f:
+        cfg = json.load(f)
+    p0 = cfg.get("P0", [])
+    p1 = cfg.get("P1", "*")
+
+    def get_priority(family):
+        if any(p in family for p in p0):
+            return "P0"
+        if p1 == "*" or (isinstance(p1, list) and any(p in family for p in p1)):
+            return "P1"
+        return "P2"
+
+    models = [m for m in models if get_priority(m.get("family", "")) == priority_filter]
+
+if family_filter:
+    models = [m for m in models if family_filter in m.get("family", "")]
+
+for m in models:
+    print(m["model"])
+PYEOF
+}
+
+# Run one model
+run_model() {
+    local model_type="$1"
+    local model_name="$2"
+    local runner="${RUNNER_MAP[$model_type]}"
+    local extra_args="${RUNNER_EXTRA_ARGS[$model_type]}"
+
+    local m_name="${model_name//\//_}"
+    m_name="${m_name// /_}"
+
+    # Set or clear QAIC debug env vars before running the model
+    if [ "$QAIC_DEBUG" -eq 1 ]; then
+        source "${EAGER_DIR}/export_qaic_debug.sh"
+    else
+        source "${EAGER_DIR}/unset_qaic_debug.sh"
+    fi
+
+    # Build log file paths: log_<debug>_<model>_tp<N>.log and parse_<debug>_<model>_tp<N>.log
+    local logname="${LOGS_DIR}/log_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
+    local parse_logname="${LOGS_DIR}/parse_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
+
+    logsave "${logname}" python "${EAGER_DIR}/${runner}" \
+        --model-name "${model_name}" \
+        --tp-size "${TP_SIZE}" \
+        ${extra_args}
+
+    # Parse the log to extract fallback ops and write to parse log
+    log_path="${logname}"
+    logsave "${parse_logname}" python "${EAGER_DIR}/fallback_parser.py" \
+        --file-name "${log_path}"
+
+    echo "sleeping for ${SLEEP_BETWEEN}s.."
+    sleep "${SLEEP_BETWEEN}"
+    echo "awakening.."
+}
+
+# Determine which types to run
+# Expand "all" to the ordered list in ALL_TYPES; otherwise use the single type given
+if [ "$TYPE" = "all" ]; then
+    TYPES=("${ALL_TYPES[@]}")
+else
+    TYPES=("$TYPE")
+fi
+
+# Main loop
+# For each type: find its JSON, filter models by priority/family, run each one
+for model_type in "${TYPES[@]}"; do
+
+    # Single-model mode: bypass JSON entirely and run the given model directly
+    if [ -n "$MODEL" ]; then
+        run_model "$model_type" "$MODEL"
+        continue
+    fi
+
+    json_file="${MODELS_DIR}/${JSON_PREFIX[$model_type]}.json"
+
+    # Skip this type if the scraped JSON for the given ref doesn't exist
+    if [ ! -f "$json_file" ]; then
+        echo "Warning: JSON not found: ${json_file} — skipping ${model_type}"
+        continue
+    fi
+
+    while IFS= read -r model_name; do
+        [ -z "$model_name" ] && continue
+        run_model "$model_type" "$model_name"
+    done < <(get_models "$json_file")
+done
+
+# Aggregate all parse logs into a per-type Excel sheet once all models are done
+python3 "${EAGER_DIR}/parse_logs_to_excel.py" \
+    --log-dir "${LOGS_DIR}" \
+    --models-dir "${MODELS_DIR}"

--- a/ci_scripts/ci_fallback_ops.sh
+++ b/ci_scripts/ci_fallback_ops.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
 # ------------------------------------------------------------------
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
-#!/bin/bash
 
 #################### ci_fallback_ops.sh ##############################
 # CI script for collecting fallback ops across model types.
@@ -15,7 +15,10 @@
 #   --model      <model_id>     Run a single model directly (requires --type llm|vlm)
 #   --priority   P0|P1|P2       Priority tier filter (default: all)
 #   --family     <name>         Run only models matching this family name
-#   --tp-size    <N>            Tensor parallel size (default: 4)
+#   --tp-size    <N>            Default tensor parallel size (default: 4). A model
+#                               with a pinned tp_size in model_configs_<type>.py
+#                               overrides this, and its log is named with the TP it
+#                               actually ran at.
 #   --logs-dir   <dir>          Log output directory (default: ./ci_logs)
 #   --models-dir <dir>          Directory containing scraped JSON files
 #   --ref        <git_ref>      vLLM ref whose model list to use, i.e.
@@ -63,15 +66,6 @@ SLEEP_BETWEEN=10
 export QAIC_FORCE_PLATFORM_QCCL=1
 export QAIC_QCCL_ALGO=tree
 export QAIC_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-
-# Auto-detect all available QAIC devices if QAIC_VISIBLE_DEVICES is not already set
-# if [ -z "${QAIC_VISIBLE_DEVICES}" ]; then
-#     _devices=$(sudo /opt/qti-aic/tools/qaic-util -q 2>/dev/null \
-#         | grep -oP '^QID \K\d+' \
-#         | sort -n | tr '\n' ',' | sed 's/,$//')
-#     [ -n "$_devices" ] && export QAIC_VISIBLE_DEVICES="$_devices"
-# fi
-
 
 # Model type registry 
 # To support a new model type:
@@ -130,7 +124,7 @@ mkdir -p "${LOGS_DIR}"
 # Python helper: filter model list from JSON
 get_models() {
     local json_file="$1"
-    python3 - "$json_file" "$PRIORITY_CFG" "$PRIORITY" "$FAMILY" << 'PYEOF'
+    python - "$json_file" "$PRIORITY_CFG" "$PRIORITY" "$FAMILY" << 'PYEOF'
 import json, sys
 
 json_file, priority_cfg_file, priority_filter, family_filter = sys.argv[1:]
@@ -185,7 +179,7 @@ resolve_json() {
         local candidate="${MODELS_DIR}/${prefix}_$(ref_suffix "$REF").json"
         if [ ! -f "$candidate" ]; then
             echo "Warning: model list not found: ${candidate} — skipping ${model_type}"
-            echo "         create it with: python3 ${EAGER_DIR}/scrape_models.py --ref ${REF} --type ${model_type} --output-dir ${MODELS_DIR}"
+            echo "         create it with: python ${EAGER_DIR}/scrape_models.py --ref ${REF} --type ${model_type} --output-dir ${MODELS_DIR}"
             return 1
         fi
         RESOLVED_JSON="$candidate"
@@ -202,7 +196,7 @@ resolve_json() {
 
     if [ ${#matches[@]} -eq 0 ]; then
         echo "Warning: no ${prefix}_<ref>.json in ${MODELS_DIR} — skipping ${model_type}"
-        echo "         create one with: python3 ${EAGER_DIR}/scrape_models.py --type ${model_type} --output-dir ${MODELS_DIR}"
+        echo "         create one with: python ${EAGER_DIR}/scrape_models.py --type ${model_type} --output-dir ${MODELS_DIR}"
         return 1
     fi
 
@@ -218,6 +212,34 @@ resolve_json() {
     fi
     echo "Using ${model_type} list: ${RESOLVED_JSON##*/} (ref ${RESOLVED_REF})"
     return 0
+}
+
+# Resolve the TP a model will actually run with.
+# Falls back to the sweep default, with a warning, when the type has no
+# model_configs_<type>.py, so a newly added model type still runs.
+effective_tp() {
+    local model_type="$1"
+    local model_name="$2"
+    local resolved
+
+    resolved=$(python - "$EAGER_DIR" "$model_type" "$model_name" "$TP_SIZE" <<'PYEOF'
+import importlib
+import sys
+
+eager_dir, model_type, model_name, default_tp = sys.argv[1:]
+sys.path.insert(0, eager_dir)
+mod = importlib.import_module(f"model_configs_{model_type}")
+# Mirror run_llms.py, which un-escapes '--' before looking up the config.
+print(mod.get_tp_size(model_name.replace("--", "/"), int(default_tp)))
+PYEOF
+    ) || resolved=""
+
+    if [[ ! "$resolved" =~ ^[0-9]+$ ]]; then
+        echo "Warning: could not resolve effective TP for ${model_name} (${model_type})," \
+             "falling back to --tp-size ${TP_SIZE}" >&2
+        resolved="$TP_SIZE"
+    fi
+    echo "$resolved"
 }
 
 # Run one model
@@ -237,13 +259,19 @@ run_model() {
         source "${EAGER_DIR}/unset_qaic_debug.sh"
     fi
 
-    # Build log file paths: log_<debug>_<model>_tp<N>.log and parse_<debug>_<model>_tp<N>.log
-    local logname="${LOGS_DIR}/log_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
-    local parse_logname="${LOGS_DIR}/parse_${QAIC_DEBUG}_${m_name}_tp${TP_SIZE}.log"
+    # TP the runner will actually use. May differ from TP_SIZE when
+    # model_configs_<type>.py pins tp_size for this model.
+    local run_tp
+    run_tp="$(effective_tp "$model_type" "$model_name")"
+    if [ "$run_tp" != "$TP_SIZE" ]; then
+        echo "Note: ${model_name} pins TP=${run_tp} (sweep default ${TP_SIZE})"
+    fi
 
-    # Both run_llms.py and run_vlms.py expose the same flag name, so a single
-    # array forwards it for every model type. Stays empty (expands to nothing)
-    # unless --delete-hf-checkpoint was passed.
+    # Build log file paths: log_<debug>_<model>_tp<N>.log and parse_<debug>_<model>_tp<N>.log
+    # <N> is the effective TP, which is what parse_logs_to_excel.py reports.
+    local logname="${LOGS_DIR}/log_${QAIC_DEBUG}_${m_name}_tp${run_tp}.log"
+    local parse_logname="${LOGS_DIR}/parse_${QAIC_DEBUG}_${m_name}_tp${run_tp}.log"
+
     local cleanup_flag=()
     if [ "$DELETE_HF_CHECKPOINT" -eq 1 ]; then
         cleanup_flag=(--delete-hf-checkpoint)
@@ -309,7 +337,7 @@ for model_type in "${TYPES[@]}"; do
 done
 
 # Aggregate all parse logs into a per-type Excel sheet once all models are done
-python3 "${EAGER_DIR}/parse_logs_to_excel.py" \
+python "${EAGER_DIR}/parse_logs_to_excel.py" \
     --log-dir "${LOGS_DIR}" \
     --models-dir "${MODELS_DIR}" \
     ${EXCEL_REF:+--ref "${EXCEL_REF}"}

--- a/ci_scripts/eager/export_qaic_debug.sh
+++ b/ci_scripts/eager/export_qaic_debug.sh
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+export QAIC_DEBUG=1

--- a/ci_scripts/eager/fallback_parser.py
+++ b/ci_scripts/eager/fallback_parser.py
@@ -31,6 +31,7 @@ def extract_fallback_ops(file_path):
                 fallback_ops_stats[op]["tt"] += time
 
     print(fallback_ops_stats)
+    return fallback_ops_stats
 
 
 if __name__ == "__main__":

--- a/ci_scripts/eager/fallback_parser.py
+++ b/ci_scripts/eager/fallback_parser.py
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+import argparse
+from collections import defaultdict
+
+import regex as re
+
+
+def extract_fallback_ops(file_path):
+    op_pattern = re.compile(r"CPU fallback op:\s*([^\s,]+),\s*execution started")
+    time_pattern = re.compile(
+        r"CPU fallback op:\s*([^\s,]+),\s*time elapsed \(us\):\s*(\d+)"
+    )
+    fallback_ops_stats: defaultdict[str, dict[str, int]] = defaultdict(
+        lambda: {"tc": 0, "tt": 0}
+    )
+
+    with open(file_path) as f:
+        for line in f:
+            ops_identified = op_pattern.search(line)
+            if ops_identified:
+                op = ops_identified.group(1)
+                fallback_ops_stats[op]["tc"] += 1
+
+            sec_identified = time_pattern.search(line)
+            if sec_identified:
+                op = sec_identified.group(1)
+                time = int(sec_identified.group(2))
+                fallback_ops_stats[op]["tt"] += time
+
+    print(fallback_ops_stats)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file-name", type=str, required=True)
+    args = parser.parse_args()
+    extract_fallback_ops(args.file_name)

--- a/ci_scripts/eager/hf_cache.py
+++ b/ci_scripts/eager/hf_cache.py
@@ -1,0 +1,72 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+"""Shared HF cache cleanup for the eager CI runners."""
+
+import os
+
+
+def _path_owned_by_current_user(path) -> bool:
+    """Owned by the uid running this process; unreadable counts as not ours."""
+    try:
+        return os.stat(path).st_uid == os.getuid()
+    except OSError:
+        return False
+
+
+def _revision_owned_by_current_user(revision) -> bool:
+    """A revision is ours only if its snapshot and every backing blob are.
+
+    Blobs matter because they hold the bytes deletion frees: a revision can
+    reference a blob another user downloaded, which delete_revisions() would
+    free once no surviving revision needs it.
+    """
+    return _path_owned_by_current_user(revision.snapshot_path) and all(
+        _path_owned_by_current_user(f.blob_path) for f in revision.files
+    )
+
+
+def delete_hf_checkpoint(model_name: str) -> None:
+    """Delete this user's cached revisions of model_name, freeing disk between runs.
+
+    Uses the cache from HF_HOME / HF_HUB_CACHE, so nothing outside it is touched.
+    Deletes only revisions this user downloaded -- the cache is often shared and
+    group-writable, and the flag authorises evicting your own downloads, not a
+    checkpoint someone else relies on. Skips local paths, runs whether or not the
+    model succeeded, and never raises, since it runs during teardown.
+    """
+    if os.path.isdir(model_name):
+        print(f"[cleanup] '{model_name}' is a local path - not deleting")
+        return
+
+    try:
+        from huggingface_hub import scan_cache_dir
+
+        cache = scan_cache_dir()
+        cached = [
+            rev
+            for repo in cache.repos
+            if repo.repo_type == "model" and repo.repo_id == model_name
+            for rev in repo.revisions
+        ]
+        deletable = [
+            rev.commit_hash for rev in cached if _revision_owned_by_current_user(rev)
+        ]
+
+        if len(deletable) != len(cached):
+            print(
+                f"[cleanup] keeping {len(cached) - len(deletable)} revision(s) of "
+                f"'{model_name}' not downloaded by this user"
+            )
+        if not deletable:
+            print(f"[cleanup] no deletable cache entry for '{model_name}'")
+            return
+
+        strategy = cache.delete_revisions(*deletable)
+        freed = strategy.expected_freed_size_str
+        strategy.execute()
+        print(f"[cleanup] deleted checkpoint '{model_name}' (freed {freed})")
+
+    except Exception as exc:  # noqa: BLE001 - teardown must not mask the run
+        print(f"[cleanup] could not delete '{model_name}': {exc}")

--- a/ci_scripts/eager/llm_models_v0.23.0.json
+++ b/ci_scripts/eager/llm_models_v0.23.0.json
@@ -26,7 +26,7 @@
   {
     "model": "skt/A.X-K1",
     "variant": "A.X-K1",
-    "family": "a.x",
+    "family": "axk",
     "arch": "AXK1ForCausalLM"
   },
   {
@@ -98,7 +98,7 @@
   {
     "model": "CohereLabs/North-Mini-Code",
     "variant": "North-Mini-Code",
-    "family": "north",
+    "family": "northminicode",
     "arch": "Cohere2MoeForCausalLM"
   },
   {
@@ -146,13 +146,13 @@
   {
     "model": "rednote-hilab/dots.llm1.base",
     "variant": "dots.llm1",
-    "family": "dots.llm",
+    "family": "dots",
     "arch": "Dots1ForCausalLM"
   },
   {
     "model": "rednote-hilab/dots.ocr",
     "variant": "dots_ocr",
-    "family": "dots",
+    "family": "dotsocr",
     "arch": "DotsOCRForCausalLM"
   },
   {
@@ -176,7 +176,7 @@
   {
     "model": "LGAI-EXAONE/K-EXAONE-236B-A23B",
     "variant": "K-EXAONE",
-    "family": "k",
+    "family": "kexaone",
     "arch": "ExaoneMoEForCausalLM"
   },
   {
@@ -302,7 +302,7 @@
   {
     "model": "EleutherAI/gpt-neox-20b",
     "variant": "GPT-NeoX",
-    "family": "gpt",
+    "family": "gptneox",
     "arch": "GPTNeoXForCausalLM"
   },
   {
@@ -326,7 +326,7 @@
   {
     "model": "openai/gpt-oss-20b",
     "variant": "GPT-OSS",
-    "family": "gpt",
+    "family": "gptoss",
     "arch": "GptOssForCausalLM"
   },
   {
@@ -362,7 +362,7 @@
   {
     "model": "ibm-research/moe-7b-1b-active-shared-experts",
     "variant": "Granite MoE Shared",
-    "family": "granite",
+    "family": "granitemoeshared",
     "arch": "GraniteMoeSharedForCausalLM"
   },
   {
@@ -386,7 +386,7 @@
   {
     "model": "tencent/Hunyuan-7B-Instruct",
     "variant": "Hunyuan Dense",
-    "family": "hunyuan",
+    "family": "hunyuandense",
     "arch": "HunYuanDenseV1ForCausalLM"
   },
   {
@@ -404,7 +404,7 @@
   {
     "model": "naver-hyperclovax/HyperCLOVAX-SEED-Think-14B",
     "variant": "HyperCLOVAX-SEED-Think-14B",
-    "family": "hyperclovax",
+    "family": "hyperclovaxseedthink",
     "arch": "HyperCLOVAXForCausalLM"
   },
   {
@@ -452,13 +452,13 @@
   {
     "model": "moonshotai/Kimi-Linear-48B-A3B-Base",
     "variant": "Kimi-Linear-48B-A3B-Base",
-    "family": "kimi",
+    "family": "kimilinear",
     "arch": "KimiLinearForCausalLM"
   },
   {
     "model": "moonshotai/Kimi-Linear-48B-A3B-Instruct",
     "variant": "Kimi-Linear-48B-A3B-Instruct",
-    "family": "kimi",
+    "family": "kimilinear",
     "arch": "KimiLinearForCausalLM"
   },
   {
@@ -494,7 +494,7 @@
   {
     "model": "meituan-longcat/LongCat-Flash-Chat",
     "variant": "LongCat-Flash",
-    "family": "longcat",
+    "family": "longcatflash",
     "arch": "LongcatFlashForCausalLM"
   },
   {
@@ -548,7 +548,7 @@
   {
     "model": "MiniMaxAI/MiniMax-Text-01-hf",
     "variant": "MiniMax-Text",
-    "family": "minimax",
+    "family": "minimaxtext",
     "arch": "MiniMaxForCausalLM"
   },
   {
@@ -572,13 +572,13 @@
   {
     "model": "mistralai/Mistral-Large-3-675B-Base-2512",
     "variant": "Mistral-Large-3-675B-Base-2512",
-    "family": "mistral",
+    "family": "mistrallarge",
     "arch": "MistralLarge3ForCausalLM"
   },
   {
     "model": "mistralai/Mistral-Large-3-675B-Instruct-2512",
     "variant": "Mistral-Large-3-675B-Instruct-2512",
-    "family": "mistral",
+    "family": "mistrallarge",
     "arch": "MistralLarge3ForCausalLM"
   },
   {
@@ -638,7 +638,7 @@
   {
     "model": "allenai/Olmo-Hybrid-7B",
     "variant": "OLMo Hybrid",
-    "family": "olmo",
+    "family": "olmohybrid",
     "arch": "OlmoHybridForCausalLM"
   },
   {
@@ -668,13 +668,13 @@
   {
     "model": "FreedomIntelligence/openPangu-Embedded-7B-V1.1",
     "variant": "openPangu-Embedded-7B",
-    "family": "openpangu",
+    "family": "openpanguembedded",
     "arch": "PanguEmbeddedForCausalLM"
   },
   {
     "model": "FreedomIntelligence/openPangu-Ultra-MoE-718B-V1.1",
     "variant": "openpangu-ultra-moe-718b-model",
-    "family": "openpangu",
+    "family": "openpanguultramoe",
     "arch": "PanguUltraMoEForCausalLM"
   },
   {
@@ -770,7 +770,7 @@
   {
     "model": "tiiuae/falcon-40b",
     "variant": "Falcon RW",
-    "family": "falcon",
+    "family": "falconrw",
     "arch": "RWForCausalLM"
   },
   {
@@ -800,7 +800,7 @@
   {
     "model": "upstage/solar-pro-preview-instruct",
     "variant": "Solar Pro",
-    "family": "solar",
+    "family": "solarpro",
     "arch": "SolarForCausalLM"
   },
   {
@@ -812,7 +812,7 @@
   {
     "model": "stabilityai/stablelm-zephyr-3b",
     "variant": "StableLM Epoch",
-    "family": "stablelm",
+    "family": "stablelmepoch",
     "arch": "StableLMEpochForCausalLM"
   },
   {
@@ -824,7 +824,7 @@
   {
     "model": "stepfun-ai/Step-Audio-EditX",
     "variant": "Step-Audio",
-    "family": "step",
+    "family": "stepaudio",
     "arch": "Step1ForCausalLM"
   },
   {
@@ -866,13 +866,13 @@
   {
     "model": "MiniMaxAI/MiniMax-M1-40k",
     "variant": "MiniMax-Text",
-    "family": "minimax",
+    "family": "minimaxtext",
     "arch": "MiniMaxM1ForCausalLM"
   },
   {
     "model": "MiniMaxAI/MiniMax-Text-01",
     "variant": "MiniMax-Text",
-    "family": "minimax",
+    "family": "minimaxtext",
     "arch": "MiniMaxText01ForCausalLM"
   },
   {

--- a/ci_scripts/eager/llm_models_v0.23.0.json
+++ b/ci_scripts/eager/llm_models_v0.23.0.json
@@ -1,0 +1,890 @@
+[
+  {
+    "model": "swiss-ai/Apertus-8B-2509",
+    "variant": "Apertus",
+    "family": "apertus",
+    "arch": "ApertusForCausalLM"
+  },
+  {
+    "model": "BAAI/Aquila-7B",
+    "variant": "Aquila",
+    "family": "aquila",
+    "arch": "AquilaForCausalLM"
+  },
+  {
+    "model": "arcee-ai/AFM-4.5B-Base",
+    "variant": "Arcee (AFM)",
+    "family": "arcee",
+    "arch": "ArceeForCausalLM"
+  },
+  {
+    "model": "Snowflake/snowflake-arctic-base",
+    "variant": "Arctic",
+    "family": "arctic",
+    "arch": "ArcticForCausalLM"
+  },
+  {
+    "model": "skt/A.X-K1",
+    "variant": "A.X-K1",
+    "family": "a.x",
+    "arch": "AXK1ForCausalLM"
+  },
+  {
+    "model": "baichuan-inc/Baichuan2-13B-Chat",
+    "variant": "Baichuan2",
+    "family": "baichuan",
+    "arch": "BaiChuanForCausalLM"
+  },
+  {
+    "model": "baichuan-inc/Baichuan-7B",
+    "variant": "Baichuan",
+    "family": "baichuan",
+    "arch": "BaiChuanForCausalLM"
+  },
+  {
+    "model": "inclusionAI/Ling-lite-1.5",
+    "variant": "Ling",
+    "family": "ling",
+    "arch": "BailingMoeForCausalLM"
+  },
+  {
+    "model": "inclusionAI/Ling-mini-2.0",
+    "variant": "Ling",
+    "family": "ling",
+    "arch": "BailingMoeV2ForCausalLM"
+  },
+  {
+    "model": "inclusionAI/Ling-2.5-1T",
+    "variant": "Ling",
+    "family": "ling",
+    "arch": "`BailingMoeV2_5ForCausalLM`"
+  },
+  {
+    "model": "ibm-ai-platform/Bamba-9B-fp8",
+    "variant": "Bamba",
+    "family": "bamba",
+    "arch": "BambaForCausalLM"
+  },
+  {
+    "model": "bigscience/bloom",
+    "variant": "BLOOM",
+    "family": "bloom",
+    "arch": "BloomForCausalLM"
+  },
+  {
+    "model": "bigscience/bloomz",
+    "variant": "BLOOMZ",
+    "family": "bloomz",
+    "arch": "BloomForCausalLM"
+  },
+  {
+    "model": "zai-org/chatglm2-6b",
+    "variant": "ChatGLM",
+    "family": "chatglm",
+    "arch": "ChatGLMModel, ChatGLMForConditionalGeneration"
+  },
+  {
+    "model": "CohereLabs/c4ai-command-r7b-12-2024",
+    "variant": "Command-R",
+    "family": "command",
+    "arch": "CohereForCausalLM, Cohere2ForCausalLM"
+  },
+  {
+    "model": "CohereLabs/c4ai-command-a-03-2025",
+    "variant": "Command-A",
+    "family": "command",
+    "arch": "CohereForCausalLM, Cohere2ForCausalLM"
+  },
+  {
+    "model": "CohereLabs/North-Mini-Code",
+    "variant": "North-Mini-Code",
+    "family": "north",
+    "arch": "Cohere2MoeForCausalLM"
+  },
+  {
+    "model": "facebook/cwm",
+    "variant": "CWM",
+    "family": "cwm",
+    "arch": "CwmForCausalLM"
+  },
+  {
+    "model": "databricks/dbrx-base",
+    "variant": "DBRX",
+    "family": "dbrx",
+    "arch": "DbrxForCausalLM"
+  },
+  {
+    "model": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+    "variant": "DeciLM",
+    "family": "decilm",
+    "arch": "DeciLMForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/deepseek-llm-7b-chat",
+    "variant": "DeepSeek",
+    "family": "deepseek",
+    "arch": "DeepseekForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/DeepSeek-V2",
+    "variant": "DeepSeek-V2",
+    "family": "deepseek",
+    "arch": "DeepseekV2ForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/DeepSeek-V3",
+    "variant": "DeepSeek-V3",
+    "family": "deepseek",
+    "arch": "DeepseekV3ForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/DeepSeek-V4-Flash",
+    "variant": "DeepSeek-V4",
+    "family": "deepseek",
+    "arch": "DeepseekV4ForCausalLM"
+  },
+  {
+    "model": "rednote-hilab/dots.llm1.base",
+    "variant": "dots.llm1",
+    "family": "dots.llm",
+    "arch": "Dots1ForCausalLM"
+  },
+  {
+    "model": "rednote-hilab/dots.ocr",
+    "variant": "dots_ocr",
+    "family": "dots",
+    "arch": "DotsOCRForCausalLM"
+  },
+  {
+    "model": "baidu/ERNIE-4.5-0.3B-PT",
+    "variant": "Ernie4.5",
+    "family": "ernie",
+    "arch": "`Ernie4_5ForCausalLM`"
+  },
+  {
+    "model": "baidu/ERNIE-4.5-21B-A3B-PT",
+    "variant": "Ernie4.5MoE",
+    "family": "ernie",
+    "arch": "`Ernie4_5_MoeForCausalLM`"
+  },
+  {
+    "model": "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct",
+    "variant": "EXAONE-3",
+    "family": "exaone",
+    "arch": "ExaoneForCausalLM"
+  },
+  {
+    "model": "LGAI-EXAONE/K-EXAONE-236B-A23B",
+    "variant": "K-EXAONE",
+    "family": "k",
+    "arch": "ExaoneMoEForCausalLM"
+  },
+  {
+    "model": "LGAI-EXAONE/EXAONE-4.0-32B",
+    "variant": "EXAONE-4",
+    "family": "exaone",
+    "arch": "Exaone4ForCausalLM"
+  },
+  {
+    "model": "mgleize/fairseq2-dummy-Llama-3.2-1B",
+    "variant": "Llama (fairseq2 format)",
+    "family": "llama",
+    "arch": "Fairseq2LlamaForCausalLM"
+  },
+  {
+    "model": "tiiuae/falcon-7b",
+    "variant": "Falcon",
+    "family": "falcon",
+    "arch": "FalconForCausalLM"
+  },
+  {
+    "model": "tiiuae/falcon-mamba-7b",
+    "variant": "FalconMamba",
+    "family": "falconmamba",
+    "arch": "FalconMambaForCausalLM"
+  },
+  {
+    "model": "tiiuae/Falcon-H1-34B-Base",
+    "variant": "Falcon-H1",
+    "family": "falcon",
+    "arch": "FalconH1ForCausalLM"
+  },
+  {
+    "model": "allenai/FlexOlmo-7x7B-1T",
+    "variant": "FlexOlmo",
+    "family": "flexolmo",
+    "arch": "FlexOlmoForCausalLM"
+  },
+  {
+    "model": "google/gemma-2b",
+    "variant": "Gemma",
+    "family": "gemma",
+    "arch": "GemmaForCausalLM"
+  },
+  {
+    "model": "google/gemma-2-9b",
+    "variant": "Gemma 2",
+    "family": "gemma",
+    "arch": "Gemma2ForCausalLM"
+  },
+  {
+    "model": "google/gemma-3-1b-it",
+    "variant": "Gemma 3",
+    "family": "gemma",
+    "arch": "Gemma3ForCausalLM"
+  },
+  {
+    "model": "google/gemma-3n-E2B-it",
+    "variant": "Gemma 3n",
+    "family": "gemma",
+    "arch": "Gemma3nForCausalLM"
+  },
+  {
+    "model": "google/gemma-4-E2B-it",
+    "variant": "Gemma 4",
+    "family": "gemma",
+    "arch": "Gemma4ForCausalLM"
+  },
+  {
+    "model": "zai-org/glm-4-9b-chat-hf",
+    "variant": "GLM-4",
+    "family": "glm",
+    "arch": "GlmForCausalLM"
+  },
+  {
+    "model": "zai-org/GLM-4-32B-0414",
+    "variant": "GLM-4-0414",
+    "family": "glm",
+    "arch": "Glm4ForCausalLM"
+  },
+  {
+    "model": "zai-org/GLM-4.5",
+    "variant": "GLM-4.5",
+    "family": "glm",
+    "arch": "Glm4MoeForCausalLM"
+  },
+  {
+    "model": "zai-org/GLM-4.7-Flash",
+    "variant": "GLM-4.7-Flash",
+    "family": "glm",
+    "arch": "Glm4MoeLiteForCausalLM"
+  },
+  {
+    "model": "openai-community/gpt2",
+    "variant": "GPT-2",
+    "family": "gpt",
+    "arch": "GPT2LMHeadModel"
+  },
+  {
+    "model": "bigcode/starcoder",
+    "variant": "StarCoder",
+    "family": "starcoder",
+    "arch": "GPTBigCodeForCausalLM"
+  },
+  {
+    "model": "bigcode/gpt_bigcode-santacoder",
+    "variant": "SantaCoder",
+    "family": "santacoder",
+    "arch": "GPTBigCodeForCausalLM"
+  },
+  {
+    "model": "WizardLM/WizardCoder-15B-V1.0",
+    "variant": "WizardCoder",
+    "family": "wizardcoder",
+    "arch": "GPTBigCodeForCausalLM"
+  },
+  {
+    "model": "EleutherAI/gpt-j-6b",
+    "variant": "GPT-J",
+    "family": "gpt",
+    "arch": "GPTJForCausalLM"
+  },
+  {
+    "model": "EleutherAI/gpt-neox-20b",
+    "variant": "GPT-NeoX",
+    "family": "gpt",
+    "arch": "GPTNeoXForCausalLM"
+  },
+  {
+    "model": "EleutherAI/pythia-12b",
+    "variant": "Pythia",
+    "family": "pythia",
+    "arch": "GPTNeoXForCausalLM"
+  },
+  {
+    "model": "databricks/dolly-v2-12b",
+    "variant": "Dolly V2",
+    "family": "dolly",
+    "arch": "GPTNeoXForCausalLM"
+  },
+  {
+    "model": "stabilityai/stablelm-tuned-alpha-7b",
+    "variant": "StableLM",
+    "family": "stablelm",
+    "arch": "GPTNeoXForCausalLM"
+  },
+  {
+    "model": "openai/gpt-oss-20b",
+    "variant": "GPT-OSS",
+    "family": "gpt",
+    "arch": "GptOssForCausalLM"
+  },
+  {
+    "model": "ibm-granite/granite-3.0-2b-base",
+    "variant": "Granite 3.0",
+    "family": "granite",
+    "arch": "GraniteForCausalLM"
+  },
+  {
+    "model": "ibm-granite/granite-3.1-8b-instruct",
+    "variant": "Granite 3.1",
+    "family": "granite",
+    "arch": "GraniteForCausalLM"
+  },
+  {
+    "model": "ibm/PowerLM-3b",
+    "variant": "PowerLM",
+    "family": "powerlm",
+    "arch": "GraniteForCausalLM"
+  },
+  {
+    "model": "ibm/PowerMoE-3b",
+    "variant": "PowerMoE",
+    "family": "powermoe",
+    "arch": "GraniteMoeForCausalLM"
+  },
+  {
+    "model": "ibm-granite/granite-4.0-tiny-preview",
+    "variant": "Granite 4.0 MoE Hybrid",
+    "family": "granite",
+    "arch": "GraniteMoeHybridForCausalLM"
+  },
+  {
+    "model": "ibm-research/moe-7b-1b-active-shared-experts",
+    "variant": "Granite MoE Shared",
+    "family": "granite",
+    "arch": "GraniteMoeSharedForCausalLM"
+  },
+  {
+    "model": "parasail-ai/GritLM-7B-vllm",
+    "variant": "GritLM",
+    "family": "gritlm",
+    "arch": "GritLM"
+  },
+  {
+    "model": "hpcai-tech/grok-1",
+    "variant": "Grok1",
+    "family": "grok",
+    "arch": "Grok1ModelForCausalLM"
+  },
+  {
+    "model": "xai-org/grok-2",
+    "variant": "Grok2",
+    "family": "grok",
+    "arch": "Grok1ForCausalLM"
+  },
+  {
+    "model": "tencent/Hunyuan-7B-Instruct",
+    "variant": "Hunyuan Dense",
+    "family": "hunyuan",
+    "arch": "HunYuanDenseV1ForCausalLM"
+  },
+  {
+    "model": "tencent/Hunyuan-A13B-Instruct",
+    "variant": "Hunyuan-A13B",
+    "family": "hunyuan",
+    "arch": "HunYuanMoEV1ForCausalLM"
+  },
+  {
+    "model": "tencent/Hy3-preview-Base",
+    "variant": "HY3",
+    "family": "hy",
+    "arch": "HYV3ForCausalLM"
+  },
+  {
+    "model": "naver-hyperclovax/HyperCLOVAX-SEED-Think-14B",
+    "variant": "HyperCLOVAX-SEED-Think-14B",
+    "family": "hyperclovax",
+    "arch": "HyperCLOVAXForCausalLM"
+  },
+  {
+    "model": "internlm/internlm-7b",
+    "variant": "InternLM",
+    "family": "internlm",
+    "arch": "InternLMForCausalLM"
+  },
+  {
+    "model": "internlm/internlm2-7b",
+    "variant": "InternLM2",
+    "family": "internlm",
+    "arch": "InternLM2ForCausalLM"
+  },
+  {
+    "model": "internlm/internlm3-8b-instruct",
+    "variant": "InternLM3",
+    "family": "internlm",
+    "arch": "InternLM3ForCausalLM"
+  },
+  {
+    "model": "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+    "variant": "IQuestCoderV1",
+    "family": "iquestcoderv",
+    "arch": "IQuestCoderForCausalLM"
+  },
+  {
+    "model": "IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct",
+    "variant": "IQuestLoopCoderV1",
+    "family": "iquestloopcoderv",
+    "arch": "IQuestLoopCoderForCausalLM"
+  },
+  {
+    "model": "inceptionai/Jais-2-8B-Chat",
+    "variant": "Jais2",
+    "family": "jais",
+    "arch": "Jais2ForCausalLM"
+  },
+  {
+    "model": "ai21labs/AI21-Jamba-1.5-Large",
+    "variant": "Jamba",
+    "family": "jamba",
+    "arch": "JambaForCausalLM"
+  },
+  {
+    "model": "moonshotai/Kimi-Linear-48B-A3B-Base",
+    "variant": "Kimi-Linear-48B-A3B-Base",
+    "family": "kimi",
+    "arch": "KimiLinearForCausalLM"
+  },
+  {
+    "model": "moonshotai/Kimi-Linear-48B-A3B-Instruct",
+    "variant": "Kimi-Linear-48B-A3B-Instruct",
+    "family": "kimi",
+    "arch": "KimiLinearForCausalLM"
+  },
+  {
+    "model": "LiquidAI/LFM2-350M",
+    "variant": "LFM2",
+    "family": "lfm",
+    "arch": "Lfm2ForCausalLM"
+  },
+  {
+    "model": "LiquidAI/LFM2-8B-A1B-preview",
+    "variant": "LFM2MoE",
+    "family": "lfm",
+    "arch": "Lfm2MoeForCausalLM"
+  },
+  {
+    "model": "meta-llama/Meta-Llama-3.1-70B",
+    "variant": "Llama 3.1",
+    "family": "llama",
+    "arch": "LlamaForCausalLM"
+  },
+  {
+    "model": "meta-llama/Llama-2-70b-hf",
+    "variant": "Llama 2",
+    "family": "llama",
+    "arch": "LlamaForCausalLM"
+  },
+  {
+    "model": "01-ai/Yi-34B",
+    "variant": "Yi",
+    "family": "yi",
+    "arch": "LlamaForCausalLM"
+  },
+  {
+    "model": "meituan-longcat/LongCat-Flash-Chat",
+    "variant": "LongCat-Flash",
+    "family": "longcat",
+    "arch": "LongcatFlashForCausalLM"
+  },
+  {
+    "model": "state-spaces/mamba-130m-hf",
+    "variant": "Mamba",
+    "family": "mamba",
+    "arch": "MambaForCausalLM"
+  },
+  {
+    "model": "mistralai/Mamba-Codestral-7B-v0.1",
+    "variant": "Mamba2",
+    "family": "mamba",
+    "arch": "Mamba2ForCausalLM"
+  },
+  {
+    "model": "JetBrains/Mellum2-12B-A2.5B-Base",
+    "variant": "Mellum 2",
+    "family": "mellum",
+    "arch": "MellumForCausalLM"
+  },
+  {
+    "model": "XiaomiMiMo/MiMo-7B-RL",
+    "variant": "MiMo",
+    "family": "mimo",
+    "arch": "MiMoForCausalLM"
+  },
+  {
+    "model": "XiaomiMiMo/MiMo-V2-Flash",
+    "variant": "MiMoV2Flash",
+    "family": "mimov",
+    "arch": "MiMoV2FlashForCausalLM"
+  },
+  {
+    "model": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "variant": "MiMoV2Pro",
+    "family": "mimov",
+    "arch": "MiMoV2ForCausalLM"
+  },
+  {
+    "model": "openbmb/MiniCPM-S-1B-sft",
+    "variant": "MiniCPM",
+    "family": "minicpm",
+    "arch": "MiniCPMForCausalLM"
+  },
+  {
+    "model": "openbmb/MiniCPM3-4B",
+    "variant": "MiniCPM3",
+    "family": "minicpm",
+    "arch": "MiniCPM3ForCausalLM"
+  },
+  {
+    "model": "MiniMaxAI/MiniMax-Text-01-hf",
+    "variant": "MiniMax-Text",
+    "family": "minimax",
+    "arch": "MiniMaxForCausalLM"
+  },
+  {
+    "model": "MiniMaxAI/MiniMax-M2",
+    "variant": "MiniMax-M2",
+    "family": "minimax",
+    "arch": "MiniMaxM2ForCausalLM"
+  },
+  {
+    "model": "mistralai/Ministral-3-3B-Instruct-2512",
+    "variant": "Ministral-3",
+    "family": "ministral",
+    "arch": "MistralForCausalLM"
+  },
+  {
+    "model": "mistralai/Mistral-7B-v0.1",
+    "variant": "Mistral",
+    "family": "mistral",
+    "arch": "MistralForCausalLM"
+  },
+  {
+    "model": "mistralai/Mistral-Large-3-675B-Base-2512",
+    "variant": "Mistral-Large-3-675B-Base-2512",
+    "family": "mistral",
+    "arch": "MistralLarge3ForCausalLM"
+  },
+  {
+    "model": "mistralai/Mistral-Large-3-675B-Instruct-2512",
+    "variant": "Mistral-Large-3-675B-Instruct-2512",
+    "family": "mistral",
+    "arch": "MistralLarge3ForCausalLM"
+  },
+  {
+    "model": "mistralai/Mixtral-8x7B-v0.1",
+    "variant": "Mixtral-8x7B",
+    "family": "mixtral",
+    "arch": "MixtralForCausalLM"
+  },
+  {
+    "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "variant": "Mixtral-8x7B-Instruct",
+    "family": "mixtral",
+    "arch": "MixtralForCausalLM"
+  },
+  {
+    "model": "mosaicml/mpt-7b",
+    "variant": "MPT",
+    "family": "mpt",
+    "arch": "MPTForCausalLM"
+  },
+  {
+    "model": "mgoin/Nemotron-4-340B-Base-hf-FP8",
+    "variant": "Nemotron-4",
+    "family": "nemotron",
+    "arch": "NemotronForCausalLM"
+  },
+  {
+    "model": "nvidia/Minitron-8B-Base",
+    "variant": "Minitron",
+    "family": "minitron",
+    "arch": "NemotronForCausalLM"
+  },
+  {
+    "model": "nvidia/Nemotron-H-8B-Base-8K",
+    "variant": "Nemotron-H",
+    "family": "nemotron",
+    "arch": "NemotronHForCausalLM"
+  },
+  {
+    "model": "allenai/OLMo-1B-hf",
+    "variant": "OLMo",
+    "family": "olmo",
+    "arch": "OlmoForCausalLM"
+  },
+  {
+    "model": "allenai/OLMo-2-0425-1B",
+    "variant": "OLMo2",
+    "family": "olmo",
+    "arch": "Olmo2ForCausalLM"
+  },
+  {
+    "model": "allenai/Olmo-3-7B-Instruct",
+    "variant": "OLMo3",
+    "family": "olmo",
+    "arch": "Olmo3ForCausalLM"
+  },
+  {
+    "model": "allenai/Olmo-Hybrid-7B",
+    "variant": "OLMo Hybrid",
+    "family": "olmo",
+    "arch": "OlmoHybridForCausalLM"
+  },
+  {
+    "model": "allenai/OLMoE-1B-7B-0924",
+    "variant": "OLMoE",
+    "family": "olmoe",
+    "arch": "OlmoeForCausalLM"
+  },
+  {
+    "model": "facebook/opt-iml-max-30b",
+    "variant": "OPT",
+    "family": "opt",
+    "arch": "OPTForCausalLM"
+  },
+  {
+    "model": "OrionStarAI/Orion-14B-Base",
+    "variant": "Orion",
+    "family": "orion",
+    "arch": "OrionForCausalLM"
+  },
+  {
+    "model": "ByteDance/Ouro-1.4B",
+    "variant": "ouro",
+    "family": "ouro",
+    "arch": "OuroForCausalLM"
+  },
+  {
+    "model": "FreedomIntelligence/openPangu-Embedded-7B-V1.1",
+    "variant": "openPangu-Embedded-7B",
+    "family": "openpangu",
+    "arch": "PanguEmbeddedForCausalLM"
+  },
+  {
+    "model": "FreedomIntelligence/openPangu-Ultra-MoE-718B-V1.1",
+    "variant": "openpangu-ultra-moe-718b-model",
+    "family": "openpangu",
+    "arch": "PanguUltraMoEForCausalLM"
+  },
+  {
+    "model": "bharatgenai/Param2-17B-A2.4B-Thinking",
+    "variant": "param2moe",
+    "family": "param",
+    "arch": "Param2MoEForCausalLM"
+  },
+  {
+    "model": "microsoft/phi-1_5",
+    "variant": "Phi",
+    "family": "phi",
+    "arch": "PhiForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-4-mini-instruct",
+    "variant": "Phi-4",
+    "family": "phi",
+    "arch": "Phi3ForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-3-mini-4k-instruct",
+    "variant": "Phi-3",
+    "family": "phi",
+    "arch": "Phi3ForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-3.5-MoE-instruct",
+    "variant": "Phi-3.5-MoE",
+    "family": "phi",
+    "arch": "PhiMoEForCausalLM"
+  },
+  {
+    "model": "adept/persimmon-8b-base",
+    "variant": "Persimmon",
+    "family": "persimmon",
+    "arch": "PersimmonForCausalLM"
+  },
+  {
+    "model": "pfnet/plamo-2-1b",
+    "variant": "PLaMo2",
+    "family": "plamo",
+    "arch": "Plamo2ForCausalLM"
+  },
+  {
+    "model": "pfnet/plamo-3-nict-2b-base",
+    "variant": "PLaMo3",
+    "family": "plamo",
+    "arch": "Plamo3ForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen-7B",
+    "variant": "Qwen",
+    "family": "qwen",
+    "arch": "QWenLMHeadModel"
+  },
+  {
+    "model": "Qwen/QwQ-32B-Preview",
+    "variant": "QwQ",
+    "family": "qwq",
+    "arch": "Qwen2ForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen2-7B-Instruct",
+    "variant": "Qwen2",
+    "family": "qwen",
+    "arch": "Qwen2ForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen1.5-MoE-A2.7B",
+    "variant": "Qwen2MoE",
+    "family": "qwen",
+    "arch": "Qwen2MoeForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen3-8B",
+    "variant": "Qwen3",
+    "family": "qwen",
+    "arch": "Qwen3ForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen3-30B-A3B",
+    "variant": "Qwen3MoE",
+    "family": "qwen",
+    "arch": "Qwen3MoeForCausalLM"
+  },
+  {
+    "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+    "variant": "Qwen3NextMoE",
+    "family": "qwen",
+    "arch": "Qwen3NextForCausalLM"
+  },
+  {
+    "model": "tiiuae/falcon-40b",
+    "variant": "Falcon RW",
+    "family": "falcon",
+    "arch": "RWForCausalLM"
+  },
+  {
+    "model": "EssentialAI/rnj-1-instruct",
+    "variant": "Rnj1",
+    "family": "rnj",
+    "arch": "Rnj1ForCausalLM"
+  },
+  {
+    "model": "sarvamai/sarvam2-30b-a3b",
+    "variant": "Sarvam 2",
+    "family": "sarvam",
+    "arch": "SarvamMoEForCausalLM"
+  },
+  {
+    "model": "sarvamai/sarvam2-105b-a9b",
+    "variant": "Sarvam 2",
+    "family": "sarvam",
+    "arch": "SarvamMLAForCausalLM"
+  },
+  {
+    "model": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    "variant": "SeedOss",
+    "family": "seedoss",
+    "arch": "SeedOssForCausalLM"
+  },
+  {
+    "model": "upstage/solar-pro-preview-instruct",
+    "variant": "Solar Pro",
+    "family": "solar",
+    "arch": "SolarForCausalLM"
+  },
+  {
+    "model": "stabilityai/stablelm-3b-4e1t",
+    "variant": "StableLM",
+    "family": "stablelm",
+    "arch": "StableLmForCausalLM"
+  },
+  {
+    "model": "stabilityai/stablelm-zephyr-3b",
+    "variant": "StableLM Epoch",
+    "family": "stablelm",
+    "arch": "StableLMEpochForCausalLM"
+  },
+  {
+    "model": "bigcode/starcoder2-3b",
+    "variant": "Starcoder2",
+    "family": "starcoder",
+    "arch": "Starcoder2ForCausalLM"
+  },
+  {
+    "model": "stepfun-ai/Step-Audio-EditX",
+    "variant": "Step-Audio",
+    "family": "step",
+    "arch": "Step1ForCausalLM"
+  },
+  {
+    "model": "stepfun-ai/Step-3.5-Flash",
+    "variant": "Step-3.5-flash",
+    "family": "step",
+    "arch": "Step3p5ForCausalLM"
+  },
+  {
+    "model": "chuhac/TeleChat2-35B",
+    "variant": "TeleChat",
+    "family": "telechat",
+    "arch": "TeleChatForCausalLM"
+  },
+  {
+    "model": "Tele-AI/TeleChat2-3B",
+    "variant": "TeleChat2",
+    "family": "telechat",
+    "arch": "TeleChat2ForCausalLM"
+  },
+  {
+    "model": "Tele-AI/TeleChat3-36B-Thinking",
+    "variant": "TeleChat3",
+    "family": "telechat",
+    "arch": "TeleChat3ForCausalLM"
+  },
+  {
+    "model": "CofeAI/Tele-FLM",
+    "variant": "TeleFLM",
+    "family": "teleflm",
+    "arch": "TeleFLMForCausalLM"
+  },
+  {
+    "model": "xverse/XVERSE-7B-Chat",
+    "variant": "XVERSE",
+    "family": "xverse",
+    "arch": "XverseForCausalLM"
+  },
+  {
+    "model": "MiniMaxAI/MiniMax-M1-40k",
+    "variant": "MiniMax-Text",
+    "family": "minimax",
+    "arch": "MiniMaxM1ForCausalLM"
+  },
+  {
+    "model": "MiniMaxAI/MiniMax-Text-01",
+    "variant": "MiniMax-Text",
+    "family": "minimax",
+    "arch": "MiniMaxText01ForCausalLM"
+  },
+  {
+    "model": "Zyphra/Zamba2-1.2B-instruct",
+    "variant": "Zamba2",
+    "family": "zamba",
+    "arch": "Zamba2ForCausalLM"
+  },
+  {
+    "model": "HuggingFaceTB/SmolLM3-3B",
+    "variant": "SmolLM3",
+    "family": "smollm",
+    "arch": "SmolLM3ForCausalLM"
+  }
+]

--- a/ci_scripts/eager/model_configs_llm.py
+++ b/ci_scripts/eager/model_configs_llm.py
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+CONFIGS = {
+    "ByteDance-Seed/Seed-OSS-36B-Instruct": {"tp_size": 8},
+    "chuhac/TeleChat2-35B": {"tp_size": 8},
+    "CofeAI/FLM-2-52B-Instruct-2407": {"tp_size": 8},
+    "CofeAI/Tele-FLM": {"tp_size": 8, "gpu_memory_utilization": 0.98},
+    "facebook/opt-66b": {"tp_size": 8},
+    "facebook/opt-iml-max-30b": {"tp_size": 8},
+    "google/gemma-2-9b": {"dtype": "float32"},
+    "google/gemma-2-27b": {"dtype": "float32"},
+    "google/gemma-3-1b-it": {"dtype": "float32"},
+    "xverse/XVERSE-7B-Chat": {"tokenizer_mode": "slow"},
+    "zai-org/GLM-4-32B-0414": {"dtype": "float32"},
+    "tiiuae/falcon-7b": {"tp_size": 1, "trust_remote_code": False},
+    "tiiuae/falcon-40b": {"tp_size": 8, "trust_remote_code": False},
+    "tiiuae/falcon-rw-7b": {"tp_size": 1, "trust_remote_code": False},
+    "tiiuae/Falcon-H1-34B-Base": {"tp_size": 8},
+    "tiiuae/Falcon-H1-34B-Instruct": {"tp_size": 8},
+    "pfnet/plamo-2-1b": {"dtype": "bfloat16"},
+    "pfnet/plamo-2-8b": {"dtype": "bfloat16"},
+    "EssentialAI/rnj-1-instruct": {"dtype": "float32"},
+    "google/gemma-2b": {"dtype": "float32"},
+    "google/gemma-3n-E2B-it": {"dtype": "float32"},
+    "upstage/solar-pro-preview-instruct": {"tp_size": 1},
+    "Zyphra/Zamba2-7B-instruct": {"tp_size": 1},
+    "microsoft/Phi-3.5-MoE-instruct": {"tp_size": 8, "gpu_memory_utilization": 0.98},
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "tp_size": 8,
+        "gpu_memory_utilization": 0.98,
+    },
+    "nvidia/Llama-3_3-Nemotron-Super-49B-v1": {
+        "tp_size": 8,
+        "gpu_memory_utilization": 0.98,
+    },
+}
+
+
+def get_config(model_name):
+    """
+    Returns the model-specific configuration dictionary for LLMs.
+    Returns an empty dict if the model is not found, allowing
+    the main script to apply its own default settings.
+    """
+    return CONFIGS.get(model_name, {})

--- a/ci_scripts/eager/model_configs_llm.py
+++ b/ci_scripts/eager/model_configs_llm.py
@@ -45,3 +45,14 @@ def get_config(model_name):
     the main script to apply its own default settings.
     """
     return CONFIGS.get(model_name, {})
+
+
+def get_tp_size(model_name, default):
+    """
+    Returns the tensor-parallel size the model will actually run with: the
+    pinned tp_size from CONFIGS if there is one, else the sweep default.
+
+    Single source of truth for the effective TP so that the runner, the log
+    file names and the Excel summary can never disagree.
+    """
+    return int(get_config(model_name).get("tp_size", default))

--- a/ci_scripts/eager/model_configs_vlm.py
+++ b/ci_scripts/eager/model_configs_vlm.py
@@ -1,0 +1,193 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+CONFIGS = {
+    "AIDC-AI/Ovis1.6-Llama3.2-3B": {"tp_size": 1, "max_model_len": 2348},
+    "AIDC-AI/Ovis2-1B": {"tp_size": 1, "max_model_len": 2348},
+    "AIDC-AI/Ovis2.5-9B": {
+        "tp_size": 8,
+        "max_model_len": 2048,
+        "prompt": "<image>\nDescribe the image in detail.",
+        "gpu_memory_utilization": 0.98,
+    },
+    "MiniMaxAI/MiniMax-VL-01": {"max_model_len": 4096},
+    "PaddlePaddle/PaddleOCR-VL": {
+        "max_model_len": 4096,
+        "prompt": "<|begin_of_sentence|>User: Describe the image in detail."
+        "<|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|\nAssistant:",
+    },  # 2063+output tokens
+    "Qwen/Qwen-VL": {
+        "max_model_len": 2048,
+        "prompt": "Describe the image in detail.Picture 1: <img></img>\n",
+        "hf_overrides": {"architectures": ["QwenVLForConditionalGeneration"]},
+    },
+    "Qwen/Qwen-VL-Chat": {
+        "max_model_len": 2048,
+        "prompt": "Describe the image in detail.Picture 1: <img></img>\n",
+        "hf_overrides": {"architectures": ["QwenVLForConditionalGeneration"]},
+    },
+    "Qwen/Qwen2-Audio-7B-Instruct": {"max_model_len": 4096},
+    "Qwen/Qwen2.5-Omni-3B": {"max_model_len": 2064},
+    "Qwen/Qwen2.5-Omni-7B": {"max_model_len": 2064},
+    "Qwen/Qwen2.5-VL-3B-Instruct": {
+        "max_model_len": 4096,
+        "prompt": "<|im_start|>system\n"
+        "You are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>\n"
+        "Describe the image in detail."
+        "<|im_end|>\n"
+        "<|im_start|>assistant\n",
+    },  # 2072+output tokens
+    "Qwen/Qwen2-VL-7B-Instruct": {"max_model_len": 4096},  # 2060+output tokens
+    "allenai/Molmo-7B-D-0924": {"max_model_len": 4096},
+    "allenai/Molmo-7B-O-0924": {"max_model_len": 4096},
+    "allenai/Molmo2-4B": {
+        "prompt": "<|image|><|im_start|>user\nDescribe the image in detail."
+        "<|im_end|>\n<|im_start|>assistant\n"
+    },
+    "allenai/Molmo2-8B": {
+        "prompt": "<|image|><|im_start|>user\nDescribe the image in detail."
+        "<|im_end|>\\n<|im_start|>assistant\n"
+    },
+    "allenai/Molmo2-O-7B": {
+        "prompt": "<|image|><|im_start|>user\nDescribe the image in detail.<|im_end|>"
+        "           \n<|im_start|>assistant\n"
+    },
+    "google/gemma-3-4b-it": {
+        "dtype": "float32",
+        "prompt": "<image>\nDescribe the image in detail.",
+    },
+    "google/gemma-3n-E2B-it": {"dtype": "float32"},
+    "google/paligemma-3b-mix-224": {"max_model_len": 4096},
+    "google/paligemma-3b-pt-224": {"max_model_len": 4096},
+    "google/paligemma2-3b-ft-docci-448": {"max_model_len": 4096},
+    "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B": {
+        "prompt": "<|im_start|>user (vector)\n"
+        "<|dummy3|><|im_end|>\n"
+        "<|im_start|>user\n"
+        "Describe the image in detail.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    },
+    "Kwai-Keye/Keye-VL-8B-Preview": {
+        "prompt": "<|vision_start|><|image_pad|><|vision_end|>\n"
+        "Describe the image in detail."
+    },
+    "Kwai-Keye/Keye-VL-1_5-8B": {
+        "prompt": "<|vision_start|><|image_pad|><|vision_end|>\n"
+        "Describe the image in detail.",
+        "max_model_len": 2060,
+    },
+    "llava-hf/LLaVA-NeXT-Video-7B-hf": {
+        "max_model_len": 4096,
+        "limit_mm_per_prompt": {
+            "image": {
+                "count": 1,
+                "width": 512,
+                "height": 512,
+            },  # Overriding default 224 resolution
+            "video": {
+                "count": 1,
+                "num_frames": 32,
+                "fps": 2,
+                "width": 640,
+                "height": 640,
+            },
+        },
+    },
+    "llava-hf/llava-1.5-7b-hf": {"max_model_len": 4096},
+    "llava-hf/llava-v1.6-mistral-7b-hf": {"max_model_len": 4096},  # 2097+output tokens
+    "llava-hf/llava-onevision-qwen2-7b-ov-hf": {
+        "max_model_len": 8000
+    },  # 7253+output tokens
+    "TIGER-Lab/Mantis-8B-siglip-llama3": {"max_model_len": 4096},
+    "microsoft/Phi-3-vision-128k-instruct": {
+        "prompt": "<|user|>\n<|image_1|>\n"
+        "Describe the image in detail.<|end|>"
+        "\n<|assistant|>\n"
+    },
+    "microsoft/Phi-3.5-vision-instruct": {
+        "prompt": "<|user|>\\n<|image_1|>\\n"
+        "Describe the image in detail."
+        "<|end|>\\n<|assistant|>\\n"
+    },
+    "microsoft/Phi-4-reasoning-vision-15B": {
+        "tp_size": 1,
+        "gpu_memory_utilization": 0.98,
+    },
+    "microsoft/Phi-4-multimodal-instruct": {
+        "prompt": "<|user|>\n"
+        "<|image_1|>\n"
+        "Describe the image in detail.\n"
+        "<|end|>\n"
+        "<|assistant|>\n"
+    },
+    "mistral-community/pixtral-12b": {"max_model_len": 4096, "mistral_tokenize": True},
+    "mistralai/Mistral-Small-3.1-24B-Instruct-2503": {
+        "max_model_len": 4096,
+        "max_num_seqs": 1,
+        "mistral_tokenize": True,
+    },
+    "nvidia/Cosmos3-Nano": {
+        "prompt": "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>\n"
+        "Describe the image in detail."
+        "<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    },
+    "openbmb/MiniCPM-o-2_6": {
+        "max_model_len": 4096,
+        "prompt": "(<image>./</image>)\nDescribe the image in detail.",
+    },
+    "Open-Bee/Bee-8B-RL": {"max_model_len": 6000},  # 5056+output tokens
+    "rhymes-ai/Aria": {
+        "prompt": "<|im_start|>user\n"
+        "<fim_prefix><|img|><fim_suffix>"
+        "Describe the image in detail."
+        "<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    },
+    "stepfun-ai/Step3-VL-10B": {
+        "prompt": "<|begin_of_sentence|> You are a helpful assistant."
+        "<|BOT|>user\\n<im_patch>Describe the image"
+        "<|EOT|><|BOT|>assistant\\n<think>\\n"
+    },
+    "Salesforce/blip2-opt-2.7b": {"max_model_len": 2048},
+    "deepseek-ai/DeepSeek-OCR": {"tp_size": 1},
+    "deepseek-ai/DeepSeek-OCR-2": {"tp_size": 2},
+    "OpenGVLab/InternVL3-1B-hf": {
+        "tp_size": 2,
+        "max_model_len": 4096,  # 2835+output tokens
+        "prompt": "<|im_start|>user\n"
+        "<img><IMG_CONTEXT></img>\n"
+        "Describe the image in detail."
+        "<|im_end|>\n"
+        "<|im_start|>assistant\n",
+    },
+    "openvla/openvla-7b": {"max_model_len": 2048},
+    "xlangai/OpenCUA-7B": {
+        "max_model_len": 2105,
+        "prompt": "<|im_start|>system\\nYou are a GUI agent."
+        "You are given a task and a screenshot of the screen."
+        "You need to perform actions to complete the task."
+        "<|im_end|>\\n<|im_start|>user\\n<|media_placeholder|>"
+        "\\nDescribe the image.\\n<|im_end|>\\n<|im_start|>assistant\\n",
+    },
+    "YannQi/R-4B": {"max_model_len": 4096},  # 2680+output tokens
+    "zai-org/GLM-4.1V-9B-Thinking": {
+        "prompt": "[gMASK]<sop><|user|><|begin_of_image|>"
+        "<|image|><|end_of_image|>Describe the image in detail."
+        "<|assistant|>"
+    },
+    "zai-org/GLM-OCR": {"prompt": "<|image|>\nDescribe the image in detail."},
+}
+
+
+def get_config(model_name):
+    """
+    Returns the model-specific configuration dictionary.
+    Returns an empty dict if the model is not found, allowing
+    main script to handle its own defaults.
+    """
+    return CONFIGS.get(model_name, {})

--- a/ci_scripts/eager/model_configs_vlm.py
+++ b/ci_scripts/eager/model_configs_vlm.py
@@ -191,3 +191,14 @@ def get_config(model_name):
     main script to handle its own defaults.
     """
     return CONFIGS.get(model_name, {})
+
+
+def get_tp_size(model_name, default):
+    """
+    Returns the tensor-parallel size the model will actually run with: the
+    pinned tp_size from CONFIGS if there is one, else the sweep default.
+
+    Single source of truth for the effective TP so that the runner, the log
+    file names and the Excel summary can never disagree.
+    """
+    return int(get_config(model_name).get("tp_size", default))

--- a/ci_scripts/eager/parse_logs_to_excel.py
+++ b/ci_scripts/eager/parse_logs_to_excel.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
 """
-Parse all parse_1_*_tp4.log files in a given directory and produce an Excel summary.
+Parse all parse_<debug>_<model>_tp<N>.log files in a given directory and produce
+an Excel summary.
 
 Usage:
     python parse_logs_to_excel.py --log-dir <path/to/logs> [--date "Apr 21 2026"]
@@ -11,6 +12,11 @@ Usage:
 If --log-dir is omitted the script's own directory is used.
 If --date is provided only log files whose second line contains that date are parsed.
 Accepted date formats: "Apr 21 2026", "Apr 21", "2026-04-21", "21 Apr 2026"
+
+Every TP size and debug flag is included by default; the TP a model actually ran
+with is reported in a per-model "TP" column. Use --tp-size / --qaic-debug to
+narrow the selection.
+
 The output Excel file is written to <log-dir>/fallback_ops_summary.xlsx.
 """
 
@@ -35,6 +41,12 @@ _DATE_INPUT_FORMATS = [
 
 # Format used inside the log file second line: "Tue Apr 21 21:36:54 2026"
 _LOG_DATE_FORMAT = "%a %b %d %H:%M:%S %Y"
+
+# parse_<debug>_<model>_tp<N>.log — the tp suffix is the *effective* TP the model
+# ran with, which may differ from the sweep's --tp-size when
+# model_configs_<type>.py pins tp_size for that model. The debug group tolerates
+# an empty slot, since sourcing unset_qaic_debug.sh can leave it blank.
+_PARSE_NAME_RE = re.compile(r"^parse_(?P<debug>\d*)_(?P<model>.+)_tp(?P<tp>\d+)\.log$")
 
 
 def parse_user_date(date_str):
@@ -95,7 +107,7 @@ def get_log_date(log_file):
 
 
 def parse_log_file(log_file):
-    """Extract the ops dict from a parse_1_*_tp4.log file."""
+    """Extract the ops dict from a parse_<debug>_<model>_tp<N>.log file."""
     with open(log_file) as f:
         content = f.read()
 
@@ -112,13 +124,15 @@ def parse_log_file(log_file):
 
 
 def check_model_ran(log_dir, parse_log_basename):
-    """Return 'Yes' if the corresponding log_1_* file shows
+    """Return 'Yes' if the corresponding log_<debug>_* file shows
     output was generated, else 'No'.
 
     Looks for 'Processed prompts: 100%' which only appears when inference completed
     and tokens were generated.
     """
-    orig_basename = parse_log_basename.replace("parse_1_", "log_1_", 1)
+    # parse_<debug>_<model>_tp<N>.log -> log_<debug>_<model>_tp<N>.log.
+    # count=1 so only the leading prefix is rewritten, never a model name.
+    orig_basename = parse_log_basename.replace("parse_", "log_", 1)
     orig_log = os.path.join(log_dir, orig_basename)
     if not os.path.exists(orig_log):
         return "N/A"
@@ -132,19 +146,29 @@ def check_model_ran(log_dir, parse_log_basename):
     return "No"
 
 
-def build_model_type_map(models_dir):
+def build_model_type_map(models_dir, ref=None):
     """
-    Read all <type>_models.json files in models_dir and return a dict
+    Read the <type>_models_<ref>.json files in models_dir and return a dict
     mapping sanitised model name (slashes→underscores) to its type string.
     E.g. {"Qwen_Qwen3-8B": "llm", "OpenGVLab_InternVL3-9B": "vlm"}
+
+    scrape_models.py stamps each file with the vLLM ref it was scraped from.
+    When ref is given only that ref's files are read; otherwise every ref found
+    is merged, which is safe because a model's type does not vary by ref.
     """
     model_type_map = {}
     if not models_dir:
         return model_type_map
-    pattern = os.path.join(models_dir, "*_models.json")
-    for json_file in sorted(glob.glob(pattern)):
+    # Mirror scrape_models.py's ref_suffix(): '/' is not filename-safe
+    suffix = ref.replace("/", "_") if ref else "*"
+    pattern = os.path.join(models_dir, f"*_models_{suffix}.json")
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        print(f"  Warning: no model list matched {pattern} — using a single sheet")
+    for json_file in matches:
         basename = os.path.basename(json_file)
-        model_type = basename.split("_models.json")[0]
+        # "llm_models_v0.23.0.json" -> "llm"; also tolerates "llm_models.json"
+        model_type = basename.split("_models")[0]
         try:
             with open(json_file) as f:
                 entries = json.load(f)
@@ -156,26 +180,33 @@ def build_model_type_map(models_dir):
     return model_type_map
 
 
-def build_sheet(writer, sheet_name, models_data, ran_status):
-    """Write one sheet to the Excel writer for the given models."""
-    all_ops = sorted({op for ops in models_data.values() for op in ops})
+def build_sheet(writer, sheet_name, records):
+    """Write one sheet to the Excel writer for the given records.
+
+    records is a list of dicts with keys: model, tp, ops, ran. A model may appear
+    more than once when it was run at several TP sizes, so rows are keyed by
+    (model, tp) rather than by model alone.
+    """
+    all_ops = sorted({op for r in records for op in r["ops"]})
 
     if not all_ops:
         print(f"  No operations found for sheet '{sheet_name}'. Writing empty sheet.")
 
     columns = pd.MultiIndex.from_tuples(
-        [("Ran?", "")] + [(op, sub) for op in all_ops for sub in ["tc", "tt"]],
+        [("Ran?", ""), ("TP", "")]
+        + [(op, sub) for op in all_ops for sub in ["tc", "tt"]],
         names=["Operation", "Metric"],
     )
 
-    index = sorted(models_data.keys())
+    records = sorted(records, key=lambda r: (r["model"], r["tp"]))
+    index = [r["model"] for r in records]
     rows = []
-    for model_name in index:
-        row = [ran_status.get(model_name, "N/A")]
+    for r in records:
+        row = [r["ran"], r["tp"]]
         for op in all_ops:
-            if op in models_data[model_name]:
-                row.append(models_data[model_name][op].get("tc", ""))
-                row.append(models_data[model_name][op].get("tt", ""))
+            if op in r["ops"]:
+                row.append(r["ops"][op].get("tc", ""))
+                row.append(r["ops"][op].get("tt", ""))
             else:
                 row.append("")
                 row.append("")
@@ -200,11 +231,21 @@ def build_sheet(writer, sheet_name, models_data, ran_status):
 
 
 def build_excel(
-    log_dir, output_file, filter_date=None, filter_has_year=True, models_dir=None
+    log_dir,
+    output_file,
+    filter_date=None,
+    filter_has_year=True,
+    models_dir=None,
+    ref=None,
+    tp_filter=None,
+    debug_filter=None,
 ):
-    log_files = sorted(glob.glob(os.path.join(log_dir, "parse_1_*_tp4.log")))
+    # Match any debug flag and any TP. The effective TP varies per model when
+    # model_configs_<type>.py pins tp_size, so it cannot be hardcoded here --
+    # doing so silently drops those runs from the spreadsheet.
+    log_files = sorted(glob.glob(os.path.join(log_dir, "parse_*_tp*.log")))
     if not log_files:
-        print(f"No parse_1_*_tp4.log files found in {log_dir}")
+        print(f"No parse_*_tp*.log files found in {log_dir}")
         return
 
     # Date filtering
@@ -235,20 +276,32 @@ def build_excel(
             return
 
     # Build model→type map from JSON files if provided; empty map = single sheet mode
-    model_type_map = build_model_type_map(models_dir)
+    model_type_map = build_model_type_map(models_dir, ref)
 
     # Parse all log files, group by type (or single bucket if no map provided)
-    sheets = {}  # sheet_name -> {model_name: ops_dict}
-    ran_status = {}  # model_name -> 'Yes' / 'No' / 'N/A'
+    sheets = {}  # sheet_name -> [record, ...]
+    skipped = 0
 
     for log_file in log_files:
         basename = os.path.basename(log_file)
-        model_name = basename[len("parse_1_") : -len(".log")]
-        model_name = re.sub(r"_tp\d+$", "", model_name)
+        m = _PARSE_NAME_RE.match(basename)
+        if not m:
+            print(f"  Skipping (unrecognised name): {basename}")
+            skipped += 1
+            continue
+
+        model_name = m.group("model")
+        tp = int(m.group("tp"))
+        debug = m.group("debug")
+
+        if tp_filter is not None and tp != tp_filter:
+            continue
+        if debug_filter is not None and debug != str(debug_filter):
+            continue
 
         ops_dict = parse_log_file(log_file)
-        ran_status[model_name] = check_model_ran(log_dir, basename)
-        print(f"  {model_name}: {len(ops_dict)} ops  |  ran={ran_status[model_name]}")
+        ran = check_model_ran(log_dir, basename)
+        print(f"  {model_name} (tp{tp}): {len(ops_dict)} ops  |  ran={ran}")
 
         # If a type map exists use it; otherwise fall back to single sheet
         sheet = (
@@ -258,12 +311,21 @@ def build_excel(
         )
         if model_type_map and sheet != "Fallback Ops":
             sheet = sheet.upper()
-        sheets.setdefault(sheet, {})[model_name] = ops_dict
+        sheets.setdefault(sheet, []).append(
+            {"model": model_name, "tp": tp, "ops": ops_dict, "ran": ran}
+        )
+
+    if skipped:
+        print(f"  ({skipped} file(s) skipped for unrecognised names)")
+
+    if not sheets:
+        print("No log files left after filtering — nothing to write.")
+        return
 
     with pd.ExcelWriter(output_file, engine="openpyxl") as writer:
         total_models = 0
         for sheet_name in sorted(sheets.keys()):
-            build_sheet(writer, sheet_name, sheets[sheet_name], ran_status)
+            build_sheet(writer, sheet_name, sheets[sheet_name])
             total_models += len(sheets[sheet_name])
             print(f"  Sheet '{sheet_name}': {len(sheets[sheet_name])} models")
 
@@ -273,12 +335,17 @@ def build_excel(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Parse parse_1_*_tp4.log files and produce an Excel summary."
+        description=(
+            "Parse parse_<debug>_<model>_tp<N>.log files and produce an Excel summary."
+        )
     )
     parser.add_argument(
         "--log-dir",
         default=os.path.dirname(os.path.abspath(__file__)),
-        help="Directory containing parse_1_*_tp4.log files (default: script directory)",
+        help=(
+            "Directory containing parse_<debug>_<model>_tp<N>.log files "
+            "(default: script directory)"
+        ),
     )
     parser.add_argument(
         "--output",
@@ -297,7 +364,30 @@ def main():
     parser.add_argument(
         "--models-dir",
         default=None,
-        help="Directory with <type>_models.json files — enables per-type sheets",
+        help="Directory with <type>_models_<ref>.json files — enables per-type sheets",
+    )
+    parser.add_argument(
+        "--ref",
+        default=None,
+        metavar="GIT_REF",
+        help=(
+            "Only read the model lists scraped from this vLLM ref, i.e. "
+            "<type>_models_<ref>.json (default: merge every ref found)"
+        ),
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Only include logs whose effective TP is N (default: all TP sizes)",
+    )
+    parser.add_argument(
+        "--qaic-debug",
+        type=int,
+        default=None,
+        metavar="0|1",
+        help="Only include logs with this QAIC_DEBUG flag (default: all)",
     )
     args = parser.parse_args()
 
@@ -317,6 +407,12 @@ def main():
     print(f"Output file   : {output_file}")
     if args.models_dir:
         print(f"Models dir    : {args.models_dir}")
+    if args.ref:
+        print(f"Model list ref: {args.ref}")
+    if args.tp_size is not None:
+        print(f"TP filter     : {args.tp_size}")
+    if args.qaic_debug is not None:
+        print(f"Debug filter  : {args.qaic_debug}")
     if filter_date:
         year_info = str(filter_date.year) if filter_has_year else "(any year)"
         print(f"Date filter   : {filter_date.strftime('%b %d')} {year_info}")
@@ -328,6 +424,9 @@ def main():
         filter_date=filter_date,
         filter_has_year=filter_has_year,
         models_dir=args.models_dir,
+        ref=args.ref,
+        tp_filter=args.tp_size,
+        debug_filter=args.qaic_debug,
     )
 
 

--- a/ci_scripts/eager/parse_logs_to_excel.py
+++ b/ci_scripts/eager/parse_logs_to_excel.py
@@ -1,0 +1,335 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+"""
+Parse all parse_1_*_tp4.log files in a given directory and produce an Excel summary.
+
+Usage:
+    python parse_logs_to_excel.py --log-dir <path/to/logs> [--date "Apr 21 2026"]
+
+If --log-dir is omitted the script's own directory is used.
+If --date is provided only log files whose second line contains that date are parsed.
+Accepted date formats: "Apr 21 2026", "Apr 21", "2026-04-21", "21 Apr 2026"
+The output Excel file is written to <log-dir>/fallback_ops_summary.xlsx.
+"""
+
+import argparse
+import ast
+import glob
+import json
+import os
+from datetime import datetime
+
+import pandas as pd
+import regex as re
+
+# Date formats accepted from the user via --date
+_DATE_INPUT_FORMATS = [
+    "%b %d %Y",  # Apr 21 2026
+    "%b %d",  # Apr 21  (no year)
+    "%Y-%m-%d",  # 2026-04-21
+    "%d %b %Y",  # 21 Apr 2026
+    "%d %b",  # 21 Apr  (no year)
+]
+
+# Format used inside the log file second line: "Tue Apr 21 21:36:54 2026"
+_LOG_DATE_FORMAT = "%a %b %d %H:%M:%S %Y"
+
+
+def parse_user_date(date_str):
+    """Parse the user-supplied --date string into a (datetime.date, has_year) tuple.
+
+    has_year is True when the user included a year, False otherwise (only
+    month+day will be compared against the log file date).
+    """
+    date_str = date_str.strip()
+    for fmt in _DATE_INPUT_FORMATS:
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            has_year = "%Y" in fmt
+            return dt.date(), has_year
+        except ValueError:
+            continue
+    raise ValueError(
+        f"Unrecognised date format: '{date_str}'.\n"
+        "Accepted formats: 'Apr 21 2026', 'Apr 21', '2026-04-21', '21 Apr 2026'"
+    )
+
+
+def get_log_date(log_file):
+    """Read the second line of a log file and return its date as datetime.date, or None.
+
+    Expected second-line format: Tue Apr 21 21:36:54 2026
+    """
+    try:
+        with open(log_file) as f:
+            for i, line in enumerate(f):
+                if i == 1:  # zero-indexed: line index 1 == second line
+                    line = line.strip()
+                    try:
+                        dt = datetime.strptime(line, _LOG_DATE_FORMAT)
+                        return dt.date()
+                    except ValueError:
+                        # Fallback: extract date parts via regex in case of
+                        # extra whitespace or a slightly different prefix
+                        m = re.search(
+                            r"(\w{3})\s+(\w{3})\s+(\d{1,2})\s+\d{2}:\d{2}:\d{2}\s+(\d{4})",
+                            line,
+                        )
+                        if m:
+                            rebuilt = (
+                                f"{m.group(1)} {m.group(2)} "
+                                f"{int(m.group(3)):2d} 00:00:00 {m.group(4)}"
+                            )
+                            try:
+                                return datetime.strptime(
+                                    rebuilt, _LOG_DATE_FORMAT
+                                ).date()
+                            except ValueError:
+                                pass
+                    return None
+    except OSError:
+        pass
+    return None
+
+
+def parse_log_file(log_file):
+    """Extract the ops dict from a parse_1_*_tp4.log file."""
+    with open(log_file) as f:
+        content = f.read()
+
+    # Match the dict portion inside defaultdict(..., {...})
+    match = re.search(r"defaultdict\([^,]+,\s*(\{.*\})\)", content)
+    if match:
+        dict_str = match.group(1)
+        try:
+            return ast.literal_eval(dict_str)
+        except Exception as e:
+            raise ValueError(f"Could not parse dict in {log_file}") from e
+            return {}
+    return {}
+
+
+def check_model_ran(log_dir, parse_log_basename):
+    """Return 'Yes' if the corresponding log_1_* file shows
+    output was generated, else 'No'.
+
+    Looks for 'Processed prompts: 100%' which only appears when inference completed
+    and tokens were generated.
+    """
+    orig_basename = parse_log_basename.replace("parse_1_", "log_1_", 1)
+    orig_log = os.path.join(log_dir, orig_basename)
+    if not os.path.exists(orig_log):
+        return "N/A"
+    try:
+        with open(orig_log) as f:
+            for line in f:
+                if "Processed prompts: 100%" in line:
+                    return "Yes"
+    except OSError:
+        return "N/A"
+    return "No"
+
+
+def build_model_type_map(models_dir):
+    """
+    Read all <type>_models.json files in models_dir and return a dict
+    mapping sanitised model name (slashes→underscores) to its type string.
+    E.g. {"Qwen_Qwen3-8B": "llm", "OpenGVLab_InternVL3-9B": "vlm"}
+    """
+    model_type_map = {}
+    if not models_dir:
+        return model_type_map
+    pattern = os.path.join(models_dir, "*_models.json")
+    for json_file in sorted(glob.glob(pattern)):
+        basename = os.path.basename(json_file)
+        model_type = basename.split("_models.json")[0]
+        try:
+            with open(json_file) as f:
+                entries = json.load(f)
+            for e in entries:
+                sanitised = e["model"].replace("/", "_").replace(" ", "_")
+                model_type_map[sanitised] = model_type
+        except Exception as exc:
+            print(f"  Warning: could not read {json_file}: {exc}")
+    return model_type_map
+
+
+def build_sheet(writer, sheet_name, models_data, ran_status):
+    """Write one sheet to the Excel writer for the given models."""
+    all_ops = sorted({op for ops in models_data.values() for op in ops})
+
+    if not all_ops:
+        print(f"  No operations found for sheet '{sheet_name}'. Writing empty sheet.")
+
+    columns = pd.MultiIndex.from_tuples(
+        [("Ran?", "")] + [(op, sub) for op in all_ops for sub in ["tc", "tt"]],
+        names=["Operation", "Metric"],
+    )
+
+    index = sorted(models_data.keys())
+    rows = []
+    for model_name in index:
+        row = [ran_status.get(model_name, "N/A")]
+        for op in all_ops:
+            if op in models_data[model_name]:
+                row.append(models_data[model_name][op].get("tc", ""))
+                row.append(models_data[model_name][op].get("tt", ""))
+            else:
+                row.append("")
+                row.append("")
+        rows.append(row)
+
+    df = pd.DataFrame(rows, index=index, columns=columns)
+    df.index.name = "Model"
+    df.to_excel(writer, sheet_name=sheet_name)
+
+    # Auto-fit column widths
+    from openpyxl.cell.cell import MergedCell
+    from openpyxl.utils import get_column_letter
+
+    ws = writer.sheets[sheet_name]
+    for col_idx in range(1, ws.max_column + 1):
+        col_letter = get_column_letter(col_idx)
+        max_len = 0
+        for cell in ws[col_letter]:
+            if not isinstance(cell, MergedCell) and cell.value is not None:
+                max_len = max(max_len, len(str(cell.value)))
+        ws.column_dimensions[col_letter].width = min(max_len + 4, 45)
+
+
+def build_excel(
+    log_dir, output_file, filter_date=None, filter_has_year=True, models_dir=None
+):
+    log_files = sorted(glob.glob(os.path.join(log_dir, "parse_1_*_tp4.log")))
+    if not log_files:
+        print(f"No parse_1_*_tp4.log files found in {log_dir}")
+        return
+
+    # Date filtering
+    if filter_date is not None:
+        filtered = []
+        for lf in log_files:
+            log_date = get_log_date(lf)
+            if log_date is None:
+                print(f"  Skipping (no date in second line): {os.path.basename(lf)}")
+                continue
+            if filter_has_year:
+                match = log_date == filter_date
+            else:
+                match = (
+                    log_date.month == filter_date.month
+                    and log_date.day == filter_date.day
+                )
+            if match:
+                filtered.append(lf)
+            else:
+                print(
+                    f"  Skipping (date {log_date} != {filter_date}): "
+                    f"{os.path.basename(lf)}"
+                )
+        log_files = filtered
+        if not log_files:
+            print(f"No log files matched date filter '{filter_date}'.")
+            return
+
+    # Build model→type map from JSON files if provided; empty map = single sheet mode
+    model_type_map = build_model_type_map(models_dir)
+
+    # Parse all log files, group by type (or single bucket if no map provided)
+    sheets = {}  # sheet_name -> {model_name: ops_dict}
+    ran_status = {}  # model_name -> 'Yes' / 'No' / 'N/A'
+
+    for log_file in log_files:
+        basename = os.path.basename(log_file)
+        model_name = basename[len("parse_1_") : -len(".log")]
+        model_name = re.sub(r"_tp\d+$", "", model_name)
+
+        ops_dict = parse_log_file(log_file)
+        ran_status[model_name] = check_model_ran(log_dir, basename)
+        print(f"  {model_name}: {len(ops_dict)} ops  |  ran={ran_status[model_name]}")
+
+        # If a type map exists use it; otherwise fall back to single sheet
+        sheet = (
+            model_type_map.get(model_name, "Fallback Ops")
+            if model_type_map
+            else "Fallback Ops"
+        )
+        if model_type_map and sheet != "Fallback Ops":
+            sheet = sheet.upper()
+        sheets.setdefault(sheet, {})[model_name] = ops_dict
+
+    with pd.ExcelWriter(output_file, engine="openpyxl") as writer:
+        total_models = 0
+        for sheet_name in sorted(sheets.keys()):
+            build_sheet(writer, sheet_name, sheets[sheet_name], ran_status)
+            total_models += len(sheets[sheet_name])
+            print(f"  Sheet '{sheet_name}': {len(sheets[sheet_name])} models")
+
+    print(f"\nExcel written to: {output_file}")
+    print(f"Total models: {total_models}  |  Sheets: {list(sheets.keys())}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse parse_1_*_tp4.log files and produce an Excel summary."
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=os.path.dirname(os.path.abspath(__file__)),
+        help="Directory containing parse_1_*_tp4.log files (default: script directory)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output Excel file path (default: <log-dir>/fallback_ops_summary.xlsx)",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        metavar="DATE",
+        help=(
+            "Only parse log files whose second line contains this date. "
+            "Accepted formats: 'Apr 21 2026', 'Apr 21', '2026-04-21', '21 Apr 2026'"
+        ),
+    )
+    parser.add_argument(
+        "--models-dir",
+        default=None,
+        help="Directory with <type>_models.json files — enables per-type sheets",
+    )
+    args = parser.parse_args()
+
+    log_dir = os.path.abspath(args.log_dir)
+    output_file = args.output or os.path.join(log_dir, "fallback_ops_summary.xlsx")
+
+    filter_date = None
+    filter_has_year = True
+    if args.date:
+        try:
+            filter_date, filter_has_year = parse_user_date(args.date)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            raise SystemExit(1) from exc
+
+    print(f"Log directory : {log_dir}")
+    print(f"Output file   : {output_file}")
+    if args.models_dir:
+        print(f"Models dir    : {args.models_dir}")
+    if filter_date:
+        year_info = str(filter_date.year) if filter_has_year else "(any year)"
+        print(f"Date filter   : {filter_date.strftime('%b %d')} {year_info}")
+    print()
+
+    build_excel(
+        log_dir,
+        output_file,
+        filter_date=filter_date,
+        filter_has_year=filter_has_year,
+        models_dir=args.models_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci_scripts/eager/parse_logs_to_excel.py
+++ b/ci_scripts/eager/parse_logs_to_excel.py
@@ -192,9 +192,14 @@ def build_sheet(writer, sheet_name, records):
     if not all_ops:
         print(f"  No operations found for sheet '{sheet_name}'. Writing empty sheet.")
 
+    # Excel-facing labels for the per-op sub-columns. The underlying dict keys
+    # ("tc", "tt") come from fallback_parser.py's printed output and are kept
+    # as-is so existing parse_*.log files still parse correctly.
+    SUB_COLUMNS = [("Fallback Count", "tc"), ("Total Time (us)", "tt")]
+
     columns = pd.MultiIndex.from_tuples(
-        [("Ran?", ""), ("TP", "")]
-        + [(op, sub) for op in all_ops for sub in ["tc", "tt"]],
+        [("Ran?", ""), ("Fallback?", ""), ("TP", "")]
+        + [(op, label) for op in all_ops for label, _ in SUB_COLUMNS],
         names=["Operation", "Metric"],
     )
 
@@ -202,14 +207,11 @@ def build_sheet(writer, sheet_name, records):
     index = [r["model"] for r in records]
     rows = []
     for r in records:
-        row = [r["ran"], r["tp"]]
+        fallback = "Yes" if r["ops"] else "No"
+        row = [r["ran"], fallback, r["tp"]]
         for op in all_ops:
-            if op in r["ops"]:
-                row.append(r["ops"][op].get("tc", ""))
-                row.append(r["ops"][op].get("tt", ""))
-            else:
-                row.append("")
-                row.append("")
+            for _, key in SUB_COLUMNS:
+                row.append(r["ops"].get(op, {}).get(key, ""))
         rows.append(row)
 
     df = pd.DataFrame(rows, index=index, columns=columns)

--- a/ci_scripts/eager/priority_config.json
+++ b/ci_scripts/eager/priority_config.json
@@ -1,0 +1,4 @@
+{
+  "P0": ["qwen", "gemma", "phi", "deepseek", "gptoss"],
+  "P1": "*"
+}

--- a/ci_scripts/eager/run_llms.py
+++ b/ci_scripts/eager/run_llms.py
@@ -29,61 +29,119 @@ sampling_temp = 0.0
 os.environ["VLLM_QAIC_PREFILL_SEQ_LEN"] = str(seq_len)
 
 
-def test_llm_vllm(model_name: str, tp_size: int, gen_len: int):
+def delete_hf_checkpoint(model_name: str) -> None:
+    """Delete the cached HF checkpoint for model_name to free disk between runs.
+
+    Uses the cache configured by HF_HOME / HF_HUB_CACHE. Never raises, since it
+    runs during teardown and must not mask a failure from the run itself.
+
+    Skips a model_name that is a local path. Otherwise deletes unconditionally --
+    the flag is opt-in, so passing it is the authorisation to evict, and the sweep
+    has to bound disk use whether or not the model ran successfully. Ownership is
+    deliberately not consulted: a shared cache is group-writable, so the owner of
+    a repo dir is just whoever downloaded it first and says nothing about who
+    needs it.
+    """
+    if os.path.isdir(model_name):
+        print(f"[cleanup] '{model_name}' is a local path - not deleting")
+        return
+
+    try:
+        from huggingface_hub import scan_cache_dir
+
+        cache_info = scan_cache_dir()
+        revisions = []
+        for repo in cache_info.repos:
+            if repo.repo_type != "model" or repo.repo_id != model_name:
+                continue
+            revisions.extend(rev.commit_hash for rev in repo.revisions)
+
+        if not revisions:
+            print(f"[cleanup] no deletable cache entry for '{model_name}'")
+            return
+
+        strategy = cache_info.delete_revisions(*revisions)
+        freed = strategy.expected_freed_size_str
+        strategy.execute()
+        print(f"[cleanup] deleted checkpoint '{model_name}' (freed {freed})")
+
+    except Exception as exc:  # noqa: BLE001 - teardown must not mask the run
+        print(f"[cleanup] could not delete '{model_name}': {exc}")
+
+
+def cleanup(model_name=None, delete_checkpoint=False):
+    if delete_checkpoint and model_name:
+        delete_hf_checkpoint(model_name)
+
+
+def test_llm_vllm(
+    model_name: str, tp_size: int, gen_len: int, delete_hf_checkpoint=False
+):
     model_name = model_name.replace("--", "/")
     cfg = model_configs_llm.get_config(model_name)
-    tp_size = cfg.get("tp_size", tp_size)
+    # Resolve through the config module so the TP used here always matches the
+    # tp<N> suffix ci_fallback_ops.sh puts on this run's log file.
+    tp_size = model_configs_llm.get_tp_size(model_name, tp_size)
     dtype = cfg.get("dtype", "float16")
     tokenizer_mode = cfg.get("tokenizer_mode", "auto")
     trust_remote_code = cfg.get("trust_remote_code", True)
-    # Create a LLM.
-    llm = LLM(
-        model=model_name,
-        trust_remote_code=trust_remote_code,
-        max_num_seqs=decode_bsz,  # determines decode batch size
-        max_model_len=ctx_len,  # ctx_len (does not account for padding,
-        # but does account for prompt and generated tokens)
-        # quantization="bf16", # Preferred quantization
-        # kv_cache_dtype="bfloat16",  # Preferred option to same KV cache
-        # and increase performance
-        disable_log_stats=False,
-        # enable_prefix_caching=False,
-        # gpu_memory_utilization=1.0,
-        enable_prefix_caching=False,
-        enforce_eager=True,
-        async_scheduling=False,
-        long_prefill_token_threshold=seq_len,
-        dtype=dtype,
-        tokenizer_mode=tokenizer_mode,
-        tensor_parallel_size=tp_size,
-        gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.95),
-        # override_qaic_config={"prefill_max_seq_len": 128}
-    )
+    print(f"Model:{model_name}, TP_SIZE:{tp_size}, DTYPE:{dtype}")
+    # Everything below runs under try/finally so the checkpoint is still deleted
+    # when the model fails to load -- most failures happen inside LLM(), and
+    # without this each failed model would leave its full checkpoint on disk.
+    llm = None
+    results = []
+    try:
+        # Create a LLM.
+        llm = LLM(
+            model=model_name,
+            trust_remote_code=trust_remote_code,
+            max_num_seqs=decode_bsz,  # determines decode batch size
+            max_model_len=ctx_len,  # ctx_len (does not account for padding,
+            # but does account for prompt and generated tokens)
+            # quantization="bf16", # Preferred quantization
+            # kv_cache_dtype="bfloat16",  # Preferred option to same KV cache
+            # and increase performance
+            disable_log_stats=False,
+            # enable_prefix_caching=False,
+            # gpu_memory_utilization=1.0,
+            enable_prefix_caching=False,
+            enforce_eager=True,
+            async_scheduling=False,
+            long_prefill_token_threshold=seq_len,
+            dtype=dtype,
+            tokenizer_mode=tokenizer_mode,
+            tensor_parallel_size=tp_size,
+            gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.95),
+            # override_qaic_config={"prefill_max_seq_len": 128}
+        )
 
-    # Patch tokenizers whose _pad() doesn't accept the padding_side kwarg
-    # added in newer transformers versions (e.g. ChatGLMTokenizer).
-    tok = llm.get_tokenizer()
-    if tok is not None and hasattr(tok, "_pad"):
-        sig = inspect.signature(tok.__class__._pad)
-        params = sig.parameters
-        if "padding_side" not in params and not any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-        ):
-            _orig_pad = tok.__class__._pad
-            tok.__class__._pad = lambda self, *a, padding_side=None, **kw: _orig_pad(
-                self, *a, **kw
-            )
+        # Patch tokenizers whose _pad() doesn't accept the padding_side kwarg
+        # added in newer transformers versions (e.g. ChatGLMTokenizer).
+        tok = llm.get_tokenizer()
+        if tok is not None and hasattr(tok, "_pad"):
+            sig = inspect.signature(tok.__class__._pad)
+            params = sig.parameters
+            if "padding_side" not in params and not any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            ):
+                _orig_pad = tok.__class__._pad
+                tok.__class__._pad = (
+                    lambda self, *a, padding_side=None, **kw: _orig_pad(self, *a, **kw)
+                )
 
-    samplingParam = SamplingParams(
-        temperature=sampling_temp,
-        # min_tokens=gen_len,
-        max_tokens=gen_len,
-    )
-    results = llm.generate(
-        prompts,
-        sampling_params=samplingParam,
-    )
-    del llm
+        samplingParam = SamplingParams(
+            temperature=sampling_temp,
+            # min_tokens=gen_len,
+            max_tokens=gen_len,
+        )
+        results = llm.generate(
+            prompts,
+            sampling_params=samplingParam,
+        )
+    finally:
+        del llm
+        cleanup(model_name=model_name, delete_checkpoint=delete_hf_checkpoint)
 
     for r in results:
         print(f"Prompt Token Id Shape: {len(r.prompt_token_ids)}")
@@ -96,6 +154,11 @@ if __name__ == "__main__":
     parser.add_argument("--model-name", type=str, required=True)
     parser.add_argument("--tp-size", type=int, required=True)
     parser.add_argument("--gen-len", type=int, default=20)
+    parser.add_argument(
+        "--delete-hf-checkpoint",
+        action="store_true",
+        help="Delete the model's cached HF checkpoint once the run is done",
+    )
 
     args = parser.parse_args()
     test_llm_vllm(**(args.__dict__))

--- a/ci_scripts/eager/run_llms.py
+++ b/ci_scripts/eager/run_llms.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import random
 import model_configs_llm
+from hf_cache import delete_hf_checkpoint
 from vllm import LLM, SamplingParams
 
 # Sample prompts.
@@ -27,46 +28,6 @@ sampling_temp = 0.0
 
 # set QAIC specific environment variables
 os.environ["VLLM_QAIC_PREFILL_SEQ_LEN"] = str(seq_len)
-
-
-def delete_hf_checkpoint(model_name: str) -> None:
-    """Delete the cached HF checkpoint for model_name to free disk between runs.
-
-    Uses the cache configured by HF_HOME / HF_HUB_CACHE. Never raises, since it
-    runs during teardown and must not mask a failure from the run itself.
-
-    Skips a model_name that is a local path. Otherwise deletes unconditionally --
-    the flag is opt-in, so passing it is the authorisation to evict, and the sweep
-    has to bound disk use whether or not the model ran successfully. Ownership is
-    deliberately not consulted: a shared cache is group-writable, so the owner of
-    a repo dir is just whoever downloaded it first and says nothing about who
-    needs it.
-    """
-    if os.path.isdir(model_name):
-        print(f"[cleanup] '{model_name}' is a local path - not deleting")
-        return
-
-    try:
-        from huggingface_hub import scan_cache_dir
-
-        cache_info = scan_cache_dir()
-        revisions = []
-        for repo in cache_info.repos:
-            if repo.repo_type != "model" or repo.repo_id != model_name:
-                continue
-            revisions.extend(rev.commit_hash for rev in repo.revisions)
-
-        if not revisions:
-            print(f"[cleanup] no deletable cache entry for '{model_name}'")
-            return
-
-        strategy = cache_info.delete_revisions(*revisions)
-        freed = strategy.expected_freed_size_str
-        strategy.execute()
-        print(f"[cleanup] deleted checkpoint '{model_name}' (freed {freed})")
-
-    except Exception as exc:  # noqa: BLE001 - teardown must not mask the run
-        print(f"[cleanup] could not delete '{model_name}': {exc}")
 
 
 def cleanup(model_name=None, delete_checkpoint=False):

--- a/ci_scripts/eager/run_llms.py
+++ b/ci_scripts/eager/run_llms.py
@@ -79,16 +79,11 @@ def test_llm_vllm(
 ):
     model_name = model_name.replace("--", "/")
     cfg = model_configs_llm.get_config(model_name)
-    # Resolve through the config module so the TP used here always matches the
-    # tp<N> suffix ci_fallback_ops.sh puts on this run's log file.
     tp_size = model_configs_llm.get_tp_size(model_name, tp_size)
     dtype = cfg.get("dtype", "float16")
     tokenizer_mode = cfg.get("tokenizer_mode", "auto")
     trust_remote_code = cfg.get("trust_remote_code", True)
     print(f"Model:{model_name}, TP_SIZE:{tp_size}, DTYPE:{dtype}")
-    # Everything below runs under try/finally so the checkpoint is still deleted
-    # when the model fails to load -- most failures happen inside LLM(), and
-    # without this each failed model would leave its full checkpoint on disk.
     llm = None
     results = []
     try:

--- a/ci_scripts/eager/run_llms.py
+++ b/ci_scripts/eager/run_llms.py
@@ -1,0 +1,101 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+import argparse
+import inspect
+import os
+import random
+import model_configs_llm
+from vllm import LLM, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "My name is"
+    # Add more prompts here
+]
+
+random.shuffle(prompts)
+
+# define qpc parameters
+ctx_len = 256
+seq_len = 128
+decode_bsz = 1
+
+# define sampling parameters
+sampling_temp = 0.0
+
+# set QAIC specific environment variables
+os.environ["VLLM_QAIC_PREFILL_SEQ_LEN"] = str(seq_len)
+
+
+def test_llm_vllm(model_name: str, tp_size: int, gen_len: int):
+    model_name = model_name.replace("--", "/")
+    cfg = model_configs_llm.get_config(model_name)
+    tp_size = cfg.get("tp_size", tp_size)
+    dtype = cfg.get("dtype", "float16")
+    tokenizer_mode = cfg.get("tokenizer_mode", "auto")
+    trust_remote_code = cfg.get("trust_remote_code", True)
+    # Create a LLM.
+    llm = LLM(
+        model=model_name,
+        trust_remote_code=trust_remote_code,
+        max_num_seqs=decode_bsz,  # determines decode batch size
+        max_model_len=ctx_len,  # ctx_len (does not account for padding,
+        # but does account for prompt and generated tokens)
+        # quantization="bf16", # Preferred quantization
+        # kv_cache_dtype="bfloat16",  # Preferred option to same KV cache
+        # and increase performance
+        disable_log_stats=False,
+        # enable_prefix_caching=False,
+        # gpu_memory_utilization=1.0,
+        enable_prefix_caching=False,
+        enforce_eager=True,
+        async_scheduling=False,
+        long_prefill_token_threshold=seq_len,
+        dtype=dtype,
+        tokenizer_mode=tokenizer_mode,
+        tensor_parallel_size=tp_size,
+        gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.95),
+        # override_qaic_config={"prefill_max_seq_len": 128}
+    )
+
+    # Patch tokenizers whose _pad() doesn't accept the padding_side kwarg
+    # added in newer transformers versions (e.g. ChatGLMTokenizer).
+    tok = llm.get_tokenizer()
+    if tok is not None and hasattr(tok, "_pad"):
+        sig = inspect.signature(tok.__class__._pad)
+        params = sig.parameters
+        if "padding_side" not in params and not any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        ):
+            _orig_pad = tok.__class__._pad
+            tok.__class__._pad = lambda self, *a, padding_side=None, **kw: _orig_pad(
+                self, *a, **kw
+            )
+
+    samplingParam = SamplingParams(
+        temperature=sampling_temp,
+        # min_tokens=gen_len,
+        max_tokens=gen_len,
+    )
+    results = llm.generate(
+        prompts,
+        sampling_params=samplingParam,
+    )
+    del llm
+
+    for r in results:
+        print(f"Prompt Token Id Shape: {len(r.prompt_token_ids)}")
+        print(r.outputs[0].text)
+        print(f"Output Token shape {len(r.outputs[0].token_ids)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-name", type=str, required=True)
+    parser.add_argument("--tp-size", type=int, required=True)
+    parser.add_argument("--gen-len", type=int, default=20)
+
+    args = parser.parse_args()
+    test_llm_vllm(**(args.__dict__))

--- a/ci_scripts/eager/run_vlms.py
+++ b/ci_scripts/eager/run_vlms.py
@@ -1,0 +1,157 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+import argparse
+import contextlib
+import gc
+import os
+
+import model_configs_vlm
+import torch
+from PIL import Image
+
+from vllm import LLM, SamplingParams, platforms
+from vllm.distributed import destroy_model_parallel
+
+assert platforms.current_platform.device_type == "qaic", (
+    "vLLM could not detect qaic plugin"
+)
+
+
+def cleanup():
+    destroy_model_parallel()
+    with contextlib.suppress(AssertionError):
+        torch.distributed.destroy_process_group()
+    gc.collect()
+    torch.qaic.empty_cache()
+
+
+def test_vlm_vllm(model_name: str, tp_size: int, gen_len: int, model_impl="vllm"):
+    cfg = model_configs_vlm.get_config(model_name)
+    print(f"[DEBUG] Loaded config: {cfg}")
+    qcclEnabled = os.getenv("QAIC_FORCE_PLATFORM_QCCL", 0)
+    # Garbage collect so that RAM is freed for RAM limited host.
+    MAX_MODEL_LEN = cfg.get("max_model_len", 4096)
+    # KV_CACHE_SIZE = 1024 * 1024 * 1024 * 2  # 2GB KV cache memory
+    TRUST_REMOTE_CODE = True
+    hf_overrides = cfg.get("hf_overrides", None)
+    mm_limit = cfg.get(
+        "limit_mm_per_prompt",
+        {
+            # "image": {"count": 16, "width": 512, "height": 512},
+            "image": {"count": 1, "width": 160, "height": 160},
+            "video": {"count": 0, "num_frames": 32, "width": 640, "height": 640},
+        },
+    )
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    img_path = os.path.join(current_dir, "Cloud_AI_100.jpeg")
+    img = Image.open(img_path)
+
+    prompt_token_ids = None
+    if "Qwen" in model_name:
+        prompt = (
+            "USER: <|vision_start|><|image_pad|><|vision_end|>\n"
+            "Describe the image in detail.\n"
+            "ASSISTANT:"
+        )
+        # mm_processor_args = {
+        #     "max_pixels": 100
+        #     * 28
+        #     * 28,  # max visual tokens per image each visual token is 28*28.,
+        # }
+    elif "InternVL" in model_name:
+        prompt = "USER: <image>\nDescribe the image in detail.\nASSISTANT:"
+        TRUST_REMOTE_CODE = True
+    elif cfg.get("mistral_tokenize", False):
+        # Pixtral-based models use mistral-common's encode_chat_completion which
+        # expands [IMG] → full image-grid token sequence. ProcessorMixin.__call__
+        # (used by raw-text path) leaves [IMG] as a single token, causing
+        # _find_mm_placeholders to fail with "0 prompt placeholders".
+        from mistral_common.protocol.instruct.chunk import ImageChunk, TextChunk
+        from mistral_common.protocol.instruct.messages import UserMessage
+        from mistral_common.protocol.instruct.request import ChatCompletionRequest
+        from vllm.tokenizers.mistral import MistralTokenizer
+
+        tokenizer = MistralTokenizer.from_pretrained(model_name)
+        request = ChatCompletionRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        ImageChunk(image=img),
+                        TextChunk(text="Describe the image in detail."),
+                    ]
+                )
+            ]
+        )
+        result = tokenizer.mistral.encode_chat_completion(request)
+        prompt_token_ids = result.tokens
+        prompt = None
+    else:
+        prompt = "<image>\nDescribe the image in detail."
+    prompt = cfg.get("prompt", prompt)
+    effective_tp = cfg.get("tp_size", tp_size)
+    print(
+        f"Model:{model_name}, TP_SIZE:{effective_tp} "
+        # f"KV_CACHE_SIZE (MB):{KV_CACHE_SIZE / (1024 * 1024)} "
+        f"MAX_MODEL_LEN:{MAX_MODEL_LEN} "
+        f"QCCL:{qcclEnabled} "
+        f"Prompt: {prompt}\n"
+    )
+    llm = LLM(
+        model=model_name,
+        dtype=cfg.get("dtype", "float16"),
+        skip_mm_profiling=cfg.get("skip_mm_profiling", False),
+        tensor_parallel_size=effective_tp,
+        max_model_len=MAX_MODEL_LEN,
+        # quantization="fp8",
+        enforce_eager=True,
+        # kv_cache_memory_bytes=KV_CACHE_SIZE,
+        enable_prefix_caching=False,
+        # pipeline_parallel_size=2,
+        trust_remote_code=TRUST_REMOTE_CODE,
+        # mm_processor_args = cfg.get("mm_processor_kwargs", mm_processor_args),
+        hf_overrides=hf_overrides,
+        limit_mm_per_prompt=mm_limit,
+        async_scheduling=False,
+        model_impl=model_impl,
+        gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.98),
+        **({"max_num_seqs": cfg["max_num_seqs"]} if "max_num_seqs" in cfg else {}),
+    )
+
+    samplingParam = SamplingParams(
+        temperature=0.0,
+        # min_tokens=gen_len,
+        max_tokens=gen_len,
+    )
+    results = llm.generate(
+        {
+            "prompt_token_ids": prompt_token_ids,
+            "multi_modal_data": {"image": [img]},
+        }
+        if prompt_token_ids is not None
+        else {
+            "prompt": prompt,
+            "multi_modal_data": {"image": [img]},
+        },
+        sampling_params=samplingParam,
+    )
+
+    del llm
+    gc.collect()
+    cleanup()
+    for r in results:
+        print(f"Prompt Token Id Shape: {len(r.prompt_token_ids)}")
+        print(r.outputs[0].text)
+        print(f"Output Token shape {len(r.outputs[0].token_ids)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-name", type=str, required=True)
+    parser.add_argument("--tp-size", type=int, required=True)
+    parser.add_argument("--gen-len", type=int, default=20)
+    parser.add_argument("--model-impl", type=str, required=True)
+
+    args = parser.parse_args()
+    test_vlm_vllm(**(args.__dict__))

--- a/ci_scripts/eager/run_vlms.py
+++ b/ci_scripts/eager/run_vlms.py
@@ -19,15 +19,69 @@ assert platforms.current_platform.device_type == "qaic", (
 )
 
 
-def cleanup():
-    destroy_model_parallel()
-    with contextlib.suppress(AssertionError):
-        torch.distributed.destroy_process_group()
-    gc.collect()
-    torch.qaic.empty_cache()
+def delete_hf_checkpoint(model_name: str) -> None:
+    """Delete the cached HF checkpoint for model_name to free disk between runs.
+
+    Uses the cache configured by HF_HOME / HF_HUB_CACHE. Never raises, since it
+    runs during teardown and must not mask a failure from the run itself.
+
+    Skips a model_name that is a local path. Otherwise deletes unconditionally --
+    the flag is opt-in, so passing it is the authorisation to evict, and the sweep
+    has to bound disk use whether or not the model ran successfully. Ownership is
+    deliberately not consulted: a shared cache is group-writable, so the owner of
+    a repo dir is just whoever downloaded it first and says nothing about who
+    needs it.
+    """
+    if os.path.isdir(model_name):
+        print(f"[cleanup] '{model_name}' is a local path - not deleting")
+        return
+
+    try:
+        from huggingface_hub import scan_cache_dir
+
+        cache_info = scan_cache_dir()
+        revisions = []
+        for repo in cache_info.repos:
+            if repo.repo_type != "model" or repo.repo_id != model_name:
+                continue
+            revisions.extend(rev.commit_hash for rev in repo.revisions)
+
+        if not revisions:
+            print(f"[cleanup] no deletable cache entry for '{model_name}'")
+            return
+
+        strategy = cache_info.delete_revisions(*revisions)
+        freed = strategy.expected_freed_size_str
+        strategy.execute()
+        print(f"[cleanup] deleted checkpoint '{model_name}' (freed {freed})")
+
+    except Exception as exc:  # noqa: BLE001 - teardown must not mask the run
+        print(f"[cleanup] could not delete '{model_name}': {exc}")
 
 
-def test_vlm_vllm(model_name: str, tp_size: int, gen_len: int, model_impl="vllm"):
+def cleanup(model_name=None, delete_checkpoint=False):
+    # Distributed teardown is best-effort: when LLM() failed early these were
+    # never initialised and will raise. That must not stop the deletion below,
+    # which is the whole reason cleanup runs on the failure path.
+    try:
+        destroy_model_parallel()
+        with contextlib.suppress(AssertionError):
+            torch.distributed.destroy_process_group()
+        gc.collect()
+        torch.qaic.empty_cache()
+    except Exception as exc:  # noqa: BLE001 - teardown is not the priority here
+        print(f"[cleanup] distributed teardown skipped: {exc}")
+    if delete_checkpoint and model_name:
+        delete_hf_checkpoint(model_name)
+
+
+def test_vlm_vllm(
+    model_name: str,
+    tp_size: int,
+    gen_len: int,
+    model_impl="vllm",
+    delete_hf_checkpoint=False,
+):
     cfg = model_configs_vlm.get_config(model_name)
     print(f"[DEBUG] Loaded config: {cfg}")
     qcclEnabled = os.getenv("QAIC_FORCE_PLATFORM_QCCL", 0)
@@ -90,7 +144,9 @@ def test_vlm_vllm(model_name: str, tp_size: int, gen_len: int, model_impl="vllm"
     else:
         prompt = "<image>\nDescribe the image in detail."
     prompt = cfg.get("prompt", prompt)
-    effective_tp = cfg.get("tp_size", tp_size)
+    # Resolve through the config module so the TP used here always matches the
+    # tp<N> suffix ci_fallback_ops.sh puts on this run's log file.
+    effective_tp = model_configs_vlm.get_tp_size(model_name, tp_size)
     print(
         f"Model:{model_name}, TP_SIZE:{effective_tp} "
         # f"KV_CACHE_SIZE (MB):{KV_CACHE_SIZE / (1024 * 1024)} "
@@ -98,48 +154,56 @@ def test_vlm_vllm(model_name: str, tp_size: int, gen_len: int, model_impl="vllm"
         f"QCCL:{qcclEnabled} "
         f"Prompt: {prompt}\n"
     )
-    llm = LLM(
-        model=model_name,
-        dtype=cfg.get("dtype", "float16"),
-        skip_mm_profiling=cfg.get("skip_mm_profiling", False),
-        tensor_parallel_size=effective_tp,
-        max_model_len=MAX_MODEL_LEN,
-        # quantization="fp8",
-        enforce_eager=True,
-        # kv_cache_memory_bytes=KV_CACHE_SIZE,
-        enable_prefix_caching=False,
-        # pipeline_parallel_size=2,
-        trust_remote_code=TRUST_REMOTE_CODE,
-        # mm_processor_args = cfg.get("mm_processor_kwargs", mm_processor_args),
-        hf_overrides=hf_overrides,
-        limit_mm_per_prompt=mm_limit,
-        async_scheduling=False,
-        model_impl=model_impl,
-        gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.98),
-        **({"max_num_seqs": cfg["max_num_seqs"]} if "max_num_seqs" in cfg else {}),
-    )
+    # Everything below runs under try/finally so the checkpoint is still deleted
+    # when the model fails to load -- most failures happen inside LLM(), and
+    # without this each failed model would leave its full checkpoint on disk.
+    llm = None
+    results = []
+    try:
+        llm = LLM(
+            model=model_name,
+            dtype=cfg.get("dtype", "float16"),
+            skip_mm_profiling=cfg.get("skip_mm_profiling", False),
+            tensor_parallel_size=effective_tp,
+            max_model_len=MAX_MODEL_LEN,
+            # quantization="fp8",
+            enforce_eager=True,
+            enable_flashinfer_autotune=False,
+            # kv_cache_memory_bytes=KV_CACHE_SIZE,
+            enable_prefix_caching=False,
+            # pipeline_parallel_size=2,
+            trust_remote_code=TRUST_REMOTE_CODE,
+            # mm_processor_args = cfg.get("mm_processor_kwargs", mm_processor_args),
+            hf_overrides=hf_overrides,
+            limit_mm_per_prompt=mm_limit,
+            async_scheduling=False,
+            model_impl=model_impl,
+            gpu_memory_utilization=cfg.get("gpu_memory_utilization", 0.98),
+            **({"max_num_seqs": cfg["max_num_seqs"]} if "max_num_seqs" in cfg else {}),
+        )
 
-    samplingParam = SamplingParams(
-        temperature=0.0,
-        # min_tokens=gen_len,
-        max_tokens=gen_len,
-    )
-    results = llm.generate(
-        {
-            "prompt_token_ids": prompt_token_ids,
-            "multi_modal_data": {"image": [img]},
-        }
-        if prompt_token_ids is not None
-        else {
-            "prompt": prompt,
-            "multi_modal_data": {"image": [img]},
-        },
-        sampling_params=samplingParam,
-    )
+        samplingParam = SamplingParams(
+            temperature=0.0,
+            # min_tokens=gen_len,
+            max_tokens=gen_len,
+        )
+        results = llm.generate(
+            {
+                "prompt_token_ids": prompt_token_ids,
+                "multi_modal_data": {"image": [img]},
+            }
+            if prompt_token_ids is not None
+            else {
+                "prompt": prompt,
+                "multi_modal_data": {"image": [img]},
+            },
+            sampling_params=samplingParam,
+        )
+    finally:
+        del llm
+        gc.collect()
+        cleanup(model_name=model_name, delete_checkpoint=delete_hf_checkpoint)
 
-    del llm
-    gc.collect()
-    cleanup()
     for r in results:
         print(f"Prompt Token Id Shape: {len(r.prompt_token_ids)}")
         print(r.outputs[0].text)
@@ -152,6 +216,11 @@ if __name__ == "__main__":
     parser.add_argument("--tp-size", type=int, required=True)
     parser.add_argument("--gen-len", type=int, default=20)
     parser.add_argument("--model-impl", type=str, required=True)
+    parser.add_argument(
+        "--delete-hf-checkpoint",
+        action="store_true",
+        help="Delete the model's cached HF checkpoint once the run is done",
+    )
 
     args = parser.parse_args()
     test_vlm_vllm(**(args.__dict__))

--- a/ci_scripts/eager/run_vlms.py
+++ b/ci_scripts/eager/run_vlms.py
@@ -60,9 +60,6 @@ def delete_hf_checkpoint(model_name: str) -> None:
 
 
 def cleanup(model_name=None, delete_checkpoint=False):
-    # Distributed teardown is best-effort: when LLM() failed early these were
-    # never initialised and will raise. That must not stop the deletion below,
-    # which is the whole reason cleanup runs on the failure path.
     try:
         destroy_model_parallel()
         with contextlib.suppress(AssertionError):
@@ -82,6 +79,22 @@ def test_vlm_vllm(
     model_impl="vllm",
     delete_hf_checkpoint=False,
 ):
+    """Run one VLM, then tear down and optionally evict its checkpoint.
+
+    The teardown wraps the whole body rather than LLM() onwards, because the hub
+    is already touched above it (MistralTokenizer.from_pretrained), and a failure
+    there still has to evict the checkpoint that was just downloaded.
+    """
+    # Un-escape '--' -> '/' as run_llms.py does: a no-op for scraped names, and
+    # only matters for a hand-typed --model.
+    model_name = model_name.replace("--", "/")
+    try:
+        _run_vlm(model_name, tp_size, gen_len, model_impl)
+    finally:
+        cleanup(model_name=model_name, delete_checkpoint=delete_hf_checkpoint)
+
+
+def _run_vlm(model_name: str, tp_size: int, gen_len: int, model_impl="vllm"):
     cfg = model_configs_vlm.get_config(model_name)
     print(f"[DEBUG] Loaded config: {cfg}")
     qcclEnabled = os.getenv("QAIC_FORCE_PLATFORM_QCCL", 0)
@@ -118,10 +131,6 @@ def test_vlm_vllm(
         prompt = "USER: <image>\nDescribe the image in detail.\nASSISTANT:"
         TRUST_REMOTE_CODE = True
     elif cfg.get("mistral_tokenize", False):
-        # Pixtral-based models use mistral-common's encode_chat_completion which
-        # expands [IMG] → full image-grid token sequence. ProcessorMixin.__call__
-        # (used by raw-text path) leaves [IMG] as a single token, causing
-        # _find_mm_placeholders to fail with "0 prompt placeholders".
         from mistral_common.protocol.instruct.chunk import ImageChunk, TextChunk
         from mistral_common.protocol.instruct.messages import UserMessage
         from mistral_common.protocol.instruct.request import ChatCompletionRequest
@@ -144,8 +153,6 @@ def test_vlm_vllm(
     else:
         prompt = "<image>\nDescribe the image in detail."
     prompt = cfg.get("prompt", prompt)
-    # Resolve through the config module so the TP used here always matches the
-    # tp<N> suffix ci_fallback_ops.sh puts on this run's log file.
     effective_tp = model_configs_vlm.get_tp_size(model_name, tp_size)
     print(
         f"Model:{model_name}, TP_SIZE:{effective_tp} "
@@ -154,9 +161,6 @@ def test_vlm_vllm(
         f"QCCL:{qcclEnabled} "
         f"Prompt: {prompt}\n"
     )
-    # Everything below runs under try/finally so the checkpoint is still deleted
-    # when the model fails to load -- most failures happen inside LLM(), and
-    # without this each failed model would leave its full checkpoint on disk.
     llm = None
     results = []
     try:
@@ -200,9 +204,9 @@ def test_vlm_vllm(
             sampling_params=samplingParam,
         )
     finally:
+        # Free device memory before the wrapper's finally tears down and evicts.
         del llm
         gc.collect()
-        cleanup(model_name=model_name, delete_checkpoint=delete_hf_checkpoint)
 
     for r in results:
         print(f"Prompt Token Id Shape: {len(r.prompt_token_ids)}")

--- a/ci_scripts/eager/run_vlms.py
+++ b/ci_scripts/eager/run_vlms.py
@@ -10,6 +10,7 @@ import os
 import model_configs_vlm
 import torch
 from PIL import Image
+from hf_cache import delete_hf_checkpoint
 
 from vllm import LLM, SamplingParams, platforms
 from vllm.distributed import destroy_model_parallel
@@ -17,46 +18,6 @@ from vllm.distributed import destroy_model_parallel
 assert platforms.current_platform.device_type == "qaic", (
     "vLLM could not detect qaic plugin"
 )
-
-
-def delete_hf_checkpoint(model_name: str) -> None:
-    """Delete the cached HF checkpoint for model_name to free disk between runs.
-
-    Uses the cache configured by HF_HOME / HF_HUB_CACHE. Never raises, since it
-    runs during teardown and must not mask a failure from the run itself.
-
-    Skips a model_name that is a local path. Otherwise deletes unconditionally --
-    the flag is opt-in, so passing it is the authorisation to evict, and the sweep
-    has to bound disk use whether or not the model ran successfully. Ownership is
-    deliberately not consulted: a shared cache is group-writable, so the owner of
-    a repo dir is just whoever downloaded it first and says nothing about who
-    needs it.
-    """
-    if os.path.isdir(model_name):
-        print(f"[cleanup] '{model_name}' is a local path - not deleting")
-        return
-
-    try:
-        from huggingface_hub import scan_cache_dir
-
-        cache_info = scan_cache_dir()
-        revisions = []
-        for repo in cache_info.repos:
-            if repo.repo_type != "model" or repo.repo_id != model_name:
-                continue
-            revisions.extend(rev.commit_hash for rev in repo.revisions)
-
-        if not revisions:
-            print(f"[cleanup] no deletable cache entry for '{model_name}'")
-            return
-
-        strategy = cache_info.delete_revisions(*revisions)
-        freed = strategy.expected_freed_size_str
-        strategy.execute()
-        print(f"[cleanup] deleted checkpoint '{model_name}' (freed {freed})")
-
-    except Exception as exc:  # noqa: BLE001 - teardown must not mask the run
-        print(f"[cleanup] could not delete '{model_name}': {exc}")
 
 
 def cleanup(model_name=None, delete_checkpoint=False):

--- a/ci_scripts/eager/scrape_models.py
+++ b/ci_scripts/eager/scrape_models.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python
 # ------------------------------------------------------------------
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
-#!/usr/bin/env python3
 """
 Scrape vLLM's supported_models.md for a given git ref, select one
 representative HF model per architecture variant (smallest by param count,

--- a/ci_scripts/eager/scrape_models.py
+++ b/ci_scripts/eager/scrape_models.py
@@ -26,6 +26,16 @@ from pathlib import Path
 RAW_URL = "https://raw.githubusercontent.com/vllm-project/vllm/{ref}/docs/models/supported_models.md"
 
 
+def ref_suffix(ref: str) -> str:
+    """Normalise a git ref into a filename suffix.
+
+    A ref may contain '/' (e.g. 'release/1.2'), which would otherwise be read as
+    a path separator. Consumers of these files (ci_fallback_ops.sh,
+    parse_logs_to_excel.py) apply the same substitution, so keep them in step.
+    """
+    return ref.replace("/", "_")
+
+
 def fetch_markdown(ref: str) -> str:
     url = RAW_URL.format(ref=ref)
     with urllib.request.urlopen(url) as resp:
@@ -329,7 +339,7 @@ def main():
         print(f"Processing {label.upper()} models...")
         entries = process(markdown, is_vlm)
 
-        json_path = out_dir / f"{label}_models.json"
+        json_path = out_dir / f"{label}_models_{ref_suffix(ref)}.json"
 
         with open(json_path, "w") as f:
             json.dump(entries, f, indent=2)

--- a/ci_scripts/eager/scrape_models.py
+++ b/ci_scripts/eager/scrape_models.py
@@ -1,0 +1,341 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+#!/usr/bin/env python3
+"""
+Scrape vLLM's supported_models.md for a given git ref, select one
+representative HF model per architecture variant (smallest by param count,
+or first listed if no size info), and write:
+  llm_models_<ref>.json
+  vlm_models_<ref>.json
+
+Usage:
+    python scrape_models.py --ref v0.9.1 --output-dir ./model_lists
+    python scrape_models.py --ref main --output-dir .
+    python scrape_models.py --ref main --type llm
+"""
+
+import regex as re
+import sys
+import json
+import argparse
+import urllib.request
+from pathlib import Path
+
+RAW_URL = "https://raw.githubusercontent.com/vllm-project/vllm/{ref}/docs/models/supported_models.md"
+
+
+def fetch_markdown(ref: str) -> str:
+    url = RAW_URL.format(ref=ref)
+    with urllib.request.urlopen(url) as resp:
+        return resp.read().decode("utf-8")
+
+
+def parse_param_count(model_id: str) -> float | None:
+    """Return param count in billions, or None if not parseable."""
+    name = model_id.split("/")[-1]
+    # Patterns like 7B, 72B, 0.5B, 1.5B, 405B, 2.6B
+    m = re.search(r"(\d+\.?\d*)[Bb](?:[^a-zA-Z]|$)", name)
+    if m:
+        return float(m.group(1))
+    # Patterns like 350M, 700M
+    m = re.search(r"(\d+\.?\d*)[Mm](?:[^a-zA-Z]|$)", name)
+    if m:
+        return float(m.group(1)) / 1000
+    return None
+
+
+def normalize(s: str) -> str:
+    """Normalize string for fuzzy matching: lowercase, remove separators."""
+    return re.sub(r"[\s\-_\.]", "", s).lower()
+
+
+def extract_family(variant: str) -> str:
+    """
+    Derive a base family name from a variant string for priority matching.
+
+    Rules (applied per token, splitting on spaces/hyphens/underscores):
+    - Accumulate tokens that have 2+ leading alpha chars
+    - If a token contains a digit it is a version marker: extract its alpha
+      prefix and stop (e.g. 'Qwen2.5' -> 'qwen', then stop)
+    - Single-char tokens (e.g. 'V' in 'V3', 'R' in 'Command-R') break the loop
+
+    Examples:
+      'Llama 3.1'   -> 'llama'
+      'DeepSeek-V3' -> 'deepseek'
+      'InternVL 3.5'-> 'internvl'
+      'GPT-OSS'     -> 'gptoss'
+      'GPT-2'       -> 'gpt'
+      'Qwen2.5-VL'  -> 'qwen'
+      'Command-R'   -> 'command'
+    """
+    tokens = re.split(r"[\s\-_]", variant.strip())
+    parts = []
+    for t in tokens:
+        m = re.match(r"^([a-zA-Z]{2,})", t)
+        if not m:
+            break
+        parts.append(m.group(1).lower())
+        if re.search(r"\d", t):
+            break
+    return "".join(parts) if parts else re.sub(r"[^a-z]", "", variant.lower())
+
+
+def extract_hf_models(cell: str) -> list:
+    """Extract HF model IDs (org/repo) from a markdown table cell."""
+    models = []
+    seen = set()
+
+    # Backtick format: `org/repo`
+    for m in re.finditer(r"`([^`\s]+/[^`\s]+)`", cell):
+        mid = m.group(1).strip()
+        if mid not in seen and not mid.startswith("http"):
+            seen.add(mid)
+            models.append(mid)
+
+    # Link format: [org/repo](url)
+    for m in re.finditer(r"\[([^\]]+)\]\([^)]*\)", cell):
+        text = m.group(1).strip()
+        if "/" in text and text not in seen and not text.startswith("http"):
+            seen.add(text)
+            models.append(text)
+
+    return models
+
+
+def extract_architectures(cell: str) -> list:
+    """Extract architecture class names from a table cell."""
+    archs = re.findall(r"`([A-Za-z][A-Za-z0-9]+)`", cell)
+    if not archs:
+        raw = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", cell).strip()
+        archs = [a.strip() for a in raw.split(",") if a.strip()]
+    return archs
+
+
+def split_variants(cell: str) -> list:
+    """Split the Models column into individual variant names."""
+    cell = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", cell)
+    cell = re.sub(r"`([^`]+)`", r"\1", cell)
+    return [v.strip() for v in cell.split(",") if v.strip()]
+
+
+def select_model(candidates: list) -> str:
+    """Pick the smallest-param model, or first if no size info available."""
+    if not candidates:
+        return ""
+    if len(candidates) == 1:
+        return candidates[0]
+    sized = [(m, parse_param_count(m)) for m in candidates]
+    with_size = [(m, s) for m, s in sized if s is not None]
+    if with_size:
+        return min(with_size, key=lambda x: x[1])[0]
+    return candidates[0]
+
+
+def match_variant_to_models(variant: str, all_models: list) -> list:
+    """Find models whose repo name contains the normalized variant string.
+    Falls back to stripping trailing zeros from the version (e.g. '3.0' -> '3')
+    to handle cases like InternVL 3.0 matching InternVL3-9B.
+    """
+    norm_v = normalize(variant)
+    matched = [m for m in all_models if norm_v in normalize(m.split("/")[-1])]
+    if not matched:
+        stripped = re.sub(r"0+$", "", norm_v)
+        if stripped != norm_v:
+            matched = [m for m in all_models if stripped in normalize(m.split("/")[-1])]
+    return matched
+
+
+def split_table_cells(line: str) -> list:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def is_separator_row(cells: list) -> bool:
+    return all(re.match(r"^[-: ]+$", c) for c in cells if c)
+
+
+def parse_tables(lines: list) -> list:
+    """
+    Walk through lines, find markdown tables with an 'Architecture' header,
+    and parse each row. Returns list of dicts: architectures, variants, hf_models.
+    """
+    rows = []
+    i = 0
+    while i < len(lines):
+        line = lines[i].rstrip()
+        if "|" not in line or "Architecture" not in line:
+            i += 1
+            continue
+
+        header_cells = split_table_cells(line)
+        try:
+            arch_idx = next(
+                j for j, c in enumerate(header_cells) if "Architecture" in c
+            )
+            model_idx = next(
+                j for j, c in enumerate(header_cells) if c.strip() == "Models"
+            )
+            hf_idx = next(
+                j for j, c in enumerate(header_cells) if "HF" in c or "Example" in c
+            )
+        except StopIteration:
+            i += 1
+            continue
+
+        i += 1  # skip header
+        if i < len(lines) and "|" in lines[i]:
+            i += 1  # skip separator row
+
+        while i < len(lines) and "|" in lines[i]:
+            cells = split_table_cells(lines[i].rstrip())
+            i += 1
+
+            if is_separator_row(cells):
+                continue
+            if max(arch_idx, model_idx, hf_idx) >= len(cells):
+                continue
+
+            archs = extract_architectures(cells[arch_idx])
+            variants = split_variants(cells[model_idx])
+            hf_models = [m for m in extract_hf_models(cells[hf_idx]) if "/" in m]
+
+            if archs and variants and hf_models:
+                rows.append(
+                    {
+                        "architectures": archs,
+                        "variants": variants,
+                        "hf_models": hf_models,
+                    }
+                )
+
+    return rows
+
+
+def get_section_lines(markdown: str, is_vlm: bool) -> list:
+    """
+    Return the lines belonging to the LLM or VLM top-level section.
+    Falls back to all lines if detection fails.
+    """
+    lines = markdown.split("\n")
+
+    llm_markers = ["text-only", "text generation", "text language"]
+    vlm_markers = ["multimodal", "vision language", "vision model"]
+    target_markers = vlm_markers if is_vlm else llm_markers
+
+    # Find all # / ## header positions
+    header_positions = [
+        (i, len(re.match(r"^(#+)", lines[i]).group(1)), lines[i])
+        for i in range(len(lines))
+        if re.match(r"^#+\s", lines[i])
+    ]
+
+    target_start = None
+    target_end = len(lines)
+
+    for pos_idx, (line_i, level, header_text) in enumerate(header_positions):
+        if any(m in header_text.lower() for m in target_markers):
+            target_start = line_i
+            # End at next header of same or higher level
+            for next_i, next_level, _ in header_positions[pos_idx + 1 :]:
+                if next_level <= level:
+                    target_end = next_i
+                    break
+            break
+
+    if target_start is None:
+        return lines
+
+    return lines[target_start:target_end]
+
+
+def process(markdown: str, is_vlm: bool) -> list:
+    """Parse section, select one model per variant, return list of entries."""
+    section_lines = get_section_lines(markdown, is_vlm)
+    rows = parse_tables(section_lines)
+
+    selected = []
+    seen_models = set()
+
+    for row in rows:
+        variants = row["variants"]
+        hf_models = row["hf_models"]
+        arch_str = ", ".join(row["architectures"])
+
+        for variant in variants:
+            matched = match_variant_to_models(variant, hf_models)
+            if not matched:
+                # Single-variant row: use all candidates
+                if len(variants) == 1:
+                    matched = hf_models
+                else:
+                    continue
+
+            model = select_model(matched)
+            if model and model not in seen_models:
+                seen_models.add(model)
+                selected.append(
+                    {
+                        "model": model,
+                        "variant": variant,
+                        "family": extract_family(variant),
+                        "arch": arch_str,
+                    }
+                )
+
+    return selected
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate LLM/VLM model lists from vLLM supported_models.md"
+    )
+    parser.add_argument(
+        "--ref",
+        default="main",
+        help="vLLM git ref (tag, branch, commit). E.g. v0.9.1, main (default: main)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory to write output files (default: current dir)",
+    )
+    parser.add_argument(
+        "--type",
+        choices=["llm", "vlm", "both"],
+        default="both",
+        help="Which model type to generate (default: both)",
+    )
+    args = parser.parse_args()
+
+    ref = args.ref
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Fetching supported_models.md @ {ref} ...")
+    try:
+        markdown = fetch_markdown(ref)
+    except Exception as e:
+        print(f"Error fetching markdown: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    targets = []
+    if args.type in ("llm", "both"):
+        targets.append((False, "llm"))
+    if args.type in ("vlm", "both"):
+        targets.append((True, "vlm"))
+
+    for is_vlm, label in targets:
+        print(f"Processing {label.upper()} models...")
+        entries = process(markdown, is_vlm)
+
+        json_path = out_dir / f"{label}_models.json"
+
+        with open(json_path, "w") as f:
+            json.dump(entries, f, indent=2)
+
+        print(f"  {len(entries)} models -> {json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci_scripts/eager/unset_qaic_debug.sh
+++ b/ci_scripts/eager/unset_qaic_debug.sh
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+unset QAIC_DEBUG

--- a/ci_scripts/eager/vlm_models_v0.23.0.json
+++ b/ci_scripts/eager/vlm_models_v0.23.0.json
@@ -1,0 +1,698 @@
+[
+  {
+    "model": "rhymes-ai/Aria",
+    "variant": "Aria",
+    "family": "aria",
+    "arch": "AriaForConditionalGeneration"
+  },
+  {
+    "model": "nvidia/audio-flamingo-3-hf",
+    "variant": "AudioFlamingo3",
+    "family": "audioflamingo",
+    "arch": "AudioFlamingo3ForConditionalGeneration"
+  },
+  {
+    "model": "CohereLabs/aya-vision-8b",
+    "variant": "Aya Vision",
+    "family": "aya",
+    "arch": "AyaVisionForConditionalGeneration"
+  },
+  {
+    "model": "ByteDance-Seed/BAGEL-7B-MoT",
+    "variant": "BAGEL",
+    "family": "bagel",
+    "arch": "BagelForConditionalGeneration"
+  },
+  {
+    "model": "Open-Bee/Bee-8B-RL",
+    "variant": "Bee-8B",
+    "family": "bee",
+    "arch": "BeeForConditionalGeneration"
+  },
+  {
+    "model": "Salesforce/blip2-opt-2.7b",
+    "variant": "BLIP-2",
+    "family": "blip",
+    "arch": "Blip2ForConditionalGeneration"
+  },
+  {
+    "model": "facebook/chameleon-7b",
+    "variant": "Chameleon",
+    "family": "chameleon",
+    "arch": "ChameleonForConditionalGeneration"
+  },
+  {
+    "model": "ai9stars/Cheers",
+    "variant": "Cheers",
+    "family": "cheers",
+    "arch": "CheersForConditionalGeneration"
+  },
+  {
+    "model": "CohereLabs/command-a-vision-07-2025",
+    "variant": "Command A Vision",
+    "family": "command",
+    "arch": "Cohere2VisionForConditionalGeneration"
+  },
+  {
+    "model": "nvidia/Cosmos3-Nano",
+    "variant": "Cosmos3 (understanding tower)",
+    "family": "cosmos",
+    "arch": "Cosmos3ForConditionalGeneration"
+  },
+  {
+    "model": "deepseek-ai/deepseek-vl2-tiny",
+    "variant": "DeepSeek-VL2",
+    "family": "deepseek",
+    "arch": "DeepseekVLV2ForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/DeepSeek-OCR",
+    "variant": "DeepSeek-OCR",
+    "family": "deepseek",
+    "arch": "DeepseekOCRForCausalLM"
+  },
+  {
+    "model": "deepseek-ai/DeepSeek-OCR-2",
+    "variant": "DeepSeek-OCR-2",
+    "family": "deepseek",
+    "arch": "DeepseekOCR2ForCausalLM"
+  },
+  {
+    "model": "nvidia/Eagle2.5-8B",
+    "variant": "Eagle2.5-VL",
+    "family": "eagle",
+    "arch": "`Eagle2_5_VLForConditionalGeneration`"
+  },
+  {
+    "model": "baidu/ERNIE-4.5-VL-28B-A3B-PT",
+    "variant": "Ernie4.5-VL",
+    "family": "ernie",
+    "arch": "`Ernie4_5_VLMoeForConditionalGeneration`"
+  },
+  {
+    "model": "LGAI-EXAONE/EXAONE-4.5-33B",
+    "variant": "EXAONE-4.5",
+    "family": "exaone",
+    "arch": "`Exaone4_5_ForConditionalGeneration`"
+  },
+  {
+    "model": "adept/fuyu-8b",
+    "variant": "Fuyu",
+    "family": "fuyu",
+    "arch": "FuyuForCausalLM"
+  },
+  {
+    "model": "google/gemma-3-4b-it",
+    "variant": "Gemma 3",
+    "family": "gemma",
+    "arch": "Gemma3ForConditionalGeneration"
+  },
+  {
+    "model": "google/gemma-3n-E2B-it",
+    "variant": "Gemma 3n",
+    "family": "gemma",
+    "arch": "Gemma3nForConditionalGeneration"
+  },
+  {
+    "model": "google/gemma-4-E2B-it",
+    "variant": "Gemma 4",
+    "family": "gemma",
+    "arch": "Gemma4ForConditionalGeneration"
+  },
+  {
+    "model": "google/gemma-4-12B-it",
+    "variant": "Gemma 4 Unified",
+    "family": "gemma",
+    "arch": "Gemma4UnifiedForConditionalGeneration"
+  },
+  {
+    "model": "zai-org/glm-4v-9b",
+    "variant": "GLM-4V",
+    "family": "glm",
+    "arch": "GLM4VForCausalLM"
+  },
+  {
+    "model": "zai-org/GLM-4.1V-9B-Thinking",
+    "variant": "GLM-4.1V-Thinking",
+    "family": "glm",
+    "arch": "Glm4vForConditionalGeneration"
+  },
+  {
+    "model": "zai-org/GLM-4.5V",
+    "variant": "GLM-4.5V",
+    "family": "glm",
+    "arch": "Glm4vMoeForConditionalGeneration"
+  },
+  {
+    "model": "zai-org/GLM-OCR",
+    "variant": "GLM-OCR",
+    "family": "glm",
+    "arch": "GlmOcrForConditionalGeneration"
+  },
+  {
+    "model": "ibm-granite/granite-4.1-3b-vision",
+    "variant": "Granite 4 Vision",
+    "family": "granite",
+    "arch": "Granite4VisionForConditionalGeneration"
+  },
+  {
+    "model": "ibm-granite/granite-speech-3.3-8b",
+    "variant": "Granite Speech",
+    "family": "granite",
+    "arch": "GraniteSpeechForConditionalGeneration"
+  },
+  {
+    "model": "ibm-granite/granite-speech-4.1-2b-plus",
+    "variant": "Granite Speech Plus",
+    "family": "granite",
+    "arch": "GraniteSpeechPlusForConditionalGeneration"
+  },
+  {
+    "model": "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B",
+    "variant": "HyperCLOVAX-SEED-Vision-Instruct-3B",
+    "family": "hyperclovax",
+    "arch": "HCXVisionForCausalLM"
+  },
+  {
+    "model": "naver-hyperclovax/HyperCLOVAX-SEED-Think-32B",
+    "variant": "HyperCLOVAX-SEED-Think-32B",
+    "family": "hyperclovax",
+    "arch": "HCXVisionV2ForCausalLM"
+  },
+  {
+    "model": "h2oai/h2ovl-mississippi-800m",
+    "variant": "H2OVL",
+    "family": "h",
+    "arch": "H2OVLChatModel"
+  },
+  {
+    "model": "tencent/HunyuanOCR",
+    "variant": "HunyuanOCR",
+    "family": "hunyuanocr",
+    "arch": "HunYuanVLForConditionalGeneration"
+  },
+  {
+    "model": "HuggingFaceM4/Idefics3-8B-Llama3",
+    "variant": "Idefics3",
+    "family": "idefics",
+    "arch": "Idefics3ForConditionalGeneration"
+  },
+  {
+    "model": "PerceptronAI/Isaac-0.1",
+    "variant": "Isaac",
+    "family": "isaac",
+    "arch": "IsaacForConditionalGeneration"
+  },
+  {
+    "model": "internlm/Intern-S1",
+    "variant": "Intern-S1",
+    "family": "intern",
+    "arch": "InternS1ForConditionalGeneration"
+  },
+  {
+    "model": "internlm/Intern-S1-Pro",
+    "variant": "Intern-S1-Pro",
+    "family": "intern",
+    "arch": "InternS1ProForConditionalGeneration"
+  },
+  {
+    "model": "internlm/Intern-S2-Preview",
+    "variant": "Intern-S2-Preview",
+    "family": "intern",
+    "arch": "InternS2PreviewForConditionalGeneration"
+  },
+  {
+    "model": "OpenGVLab/InternVL3_5-14B",
+    "variant": "InternVL 3.5",
+    "family": "internvl",
+    "arch": "InternVLChatModel"
+  },
+  {
+    "model": "OpenGVLab/InternVL3-9B",
+    "variant": "InternVL 3.0",
+    "family": "internvl",
+    "arch": "InternVLChatModel"
+  },
+  {
+    "model": "OpenGVLab/InternVideo2_5_Chat_8B",
+    "variant": "InternVideo 2.5",
+    "family": "internvideo",
+    "arch": "InternVLChatModel"
+  },
+  {
+    "model": "OpenGVLab/InternVL2_5-4B",
+    "variant": "InternVL 2.5",
+    "family": "internvl",
+    "arch": "InternVLChatModel"
+  },
+  {
+    "model": "OpenGVLab/Mono-InternVL-2B",
+    "variant": "Mono-InternVL",
+    "family": "mono",
+    "arch": "InternVLChatModel"
+  },
+  {
+    "model": "OpenGVLab/InternVL3-1B-hf",
+    "variant": "InternVL 3.0 (HF format)",
+    "family": "internvl",
+    "arch": "InternVLForConditionalGeneration"
+  },
+  {
+    "model": "kakaocorp/kanana-1.5-v-3b-instruct",
+    "variant": "Kanana-V",
+    "family": "kanana",
+    "arch": "KananaVForConditionalGeneration"
+  },
+  {
+    "model": "Kwai-Keye/Keye-VL-8B-Preview",
+    "variant": "Keye-VL-8B-Preview",
+    "family": "keye",
+    "arch": "KeyeForConditionalGeneration"
+  },
+  {
+    "model": "Kwai-Keye/Keye-VL-1_5-8B",
+    "variant": "Keye-VL-1_5-8B",
+    "family": "keye",
+    "arch": "`KeyeVL1_5ForConditionalGeneration`"
+  },
+  {
+    "model": "moonshotai/Kimi-Audio-7B-Instruct",
+    "variant": "Kimi-Audio",
+    "family": "kimi",
+    "arch": "KimiAudioForConditionalGeneration"
+  },
+  {
+    "model": "moonshotai/Kimi-K2.5",
+    "variant": "Kimi-K2.5",
+    "family": "kimi",
+    "arch": "KimiK25ForConditionalGeneration"
+  },
+  {
+    "model": "moonshotai/Kimi-VL-A3B-Instruct",
+    "variant": "Kimi-VL-A3B-Instruct",
+    "family": "kimi",
+    "arch": "KimiVLForConditionalGeneration"
+  },
+  {
+    "model": "moonshotai/Kimi-VL-A3B-Thinking",
+    "variant": "Kimi-VL-A3B-Thinking",
+    "family": "kimi",
+    "arch": "KimiVLForConditionalGeneration"
+  },
+  {
+    "model": "lightonai/LightOnOCR-1B",
+    "variant": "LightOnOCR-1B",
+    "family": "lightonocr",
+    "arch": "LightOnOCRForConditionalGeneration"
+  },
+  {
+    "model": "LiquidAI/LFM2-VL-450M",
+    "variant": "LFM2-VL",
+    "family": "lfm",
+    "arch": "Lfm2VlForConditionalGeneration"
+  },
+  {
+    "model": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+    "variant": "Llama 4",
+    "family": "llama",
+    "arch": "Llama4ForConditionalGeneration"
+  },
+  {
+    "model": "nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1",
+    "variant": "Llama Nemotron Nano VL",
+    "family": "llama",
+    "arch": "`Llama_Nemotron_Nano_VL`"
+  },
+  {
+    "model": "llava-hf/llava-1.5-7b-hf",
+    "variant": "LLaVA-1.5",
+    "family": "llava",
+    "arch": "LlavaForConditionalGeneration"
+  },
+  {
+    "model": "ibm-granite/granite-vision-3.3-2b",
+    "variant": "Granite Vision",
+    "family": "granite",
+    "arch": "LlavaNextForConditionalGeneration"
+  },
+  {
+    "model": "llava-hf/LLaVA-NeXT-Video-7B-hf",
+    "variant": "LLaVA-NeXT-Video",
+    "family": "llava",
+    "arch": "LlavaNextVideoForConditionalGeneration"
+  },
+  {
+    "model": "llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
+    "variant": "LLaVA-Onevision",
+    "family": "llava",
+    "arch": "LlavaOnevisionForConditionalGeneration"
+  },
+  {
+    "model": "mispeech/midashenglm-7b",
+    "variant": "MiDashengLM",
+    "family": "midashenglm",
+    "arch": "MiDashengLMModel"
+  },
+  {
+    "model": "XiaomiMiMo/MiMo-V2.5-Omni",
+    "variant": "MiMo-V2.5-Omni",
+    "family": "mimo",
+    "arch": "MiMoV2OmniForCausalLM"
+  },
+  {
+    "model": "openbmb/MiniCPM-o-2_6",
+    "variant": "MiniCPM-O",
+    "family": "minicpm",
+    "arch": "MiniCPMO"
+  },
+  {
+    "model": "openbmb/MiniCPM-V-2",
+    "variant": "MiniCPM-V",
+    "family": "minicpm",
+    "arch": "MiniCPMV"
+  },
+  {
+    "model": "MiniMaxAI/MiniMax-VL-01",
+    "variant": "MiniMax-VL",
+    "family": "minimax",
+    "arch": "MiniMaxVL01ForConditionalGeneration"
+  },
+  {
+    "model": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+    "variant": "Mistral3 (HF Transformers)",
+    "family": "mistral",
+    "arch": "Mistral3ForConditionalGeneration"
+  },
+  {
+    "model": "allenai/Molmo-7B-D-0924",
+    "variant": "Molmo",
+    "family": "molmo",
+    "arch": "MolmoForCausalLM"
+  },
+  {
+    "model": "allenai/Molmo2-4B",
+    "variant": "Molmo2",
+    "family": "molmo",
+    "arch": "Molmo2ForConditionalGeneration"
+  },
+  {
+    "model": "moondream/moondream3-preview",
+    "variant": "Moondream3",
+    "family": "moondream",
+    "arch": "Moondream3ForCausalLM"
+  },
+  {
+    "model": "nvidia/music-flamingo-2601-hf",
+    "variant": "MusicFlamingo",
+    "family": "musicflamingo",
+    "arch": "MusicFlamingoForConditionalGeneration"
+  },
+  {
+    "model": "nvidia/NVLM-D-72B",
+    "variant": "NVLM-D 1.0",
+    "family": "nvlm",
+    "arch": "`NVLM_D_Model`"
+  },
+  {
+    "model": "xlangai/OpenCUA-7B",
+    "variant": "OpenCUA-7B",
+    "family": "opencua",
+    "arch": "OpenCUAForConditionalGeneration"
+  },
+  {
+    "model": "FreedomIntelligence/openPangu-VL-7B",
+    "variant": "openpangu-VL",
+    "family": "openpangu",
+    "arch": "OpenPanguVLForConditionalGeneration"
+  },
+  {
+    "model": "openvla/openvla-7b",
+    "variant": "OpenVLA",
+    "family": "openvla",
+    "arch": "OpenVLAForActionPrediction"
+  },
+  {
+    "model": "AIDC-AI/Ovis2-1B",
+    "variant": "Ovis2",
+    "family": "ovis",
+    "arch": "Ovis"
+  },
+  {
+    "model": "AIDC-AI/Ovis1.6-Llama3.2-3B",
+    "variant": "Ovis1.6",
+    "family": "ovis",
+    "arch": "Ovis"
+  },
+  {
+    "model": "AIDC-AI/Ovis2.5-9B",
+    "variant": "Ovis2.5",
+    "family": "ovis",
+    "arch": "`Ovis2_5`"
+  },
+  {
+    "model": "AIDC-AI/Ovis2.6-2B",
+    "variant": "Ovis2.6",
+    "family": "ovis",
+    "arch": "`Ovis2_6ForCausalLM`"
+  },
+  {
+    "model": "AIDC-AI/Ovis2.6-30B-A3B",
+    "variant": "Ovis2.6",
+    "family": "ovis",
+    "arch": "`Ovis2_6_MoeForCausalLM`"
+  },
+  {
+    "model": "PaddlePaddle/PaddleOCR-VL",
+    "variant": "Paddle-OCR",
+    "family": "paddle",
+    "arch": "PaddleOCRVLForConditionalGeneration"
+  },
+  {
+    "model": "google/paligemma-3b-pt-224",
+    "variant": "PaliGemma",
+    "family": "paligemma",
+    "arch": "PaliGemmaForConditionalGeneration"
+  },
+  {
+    "model": "google/paligemma2-3b-ft-docci-448",
+    "variant": "PaliGemma 2",
+    "family": "paligemma",
+    "arch": "PaliGemmaForConditionalGeneration"
+  },
+  {
+    "model": "microsoft/Phi-3-vision-128k-instruct",
+    "variant": "Phi-3-Vision",
+    "family": "phi",
+    "arch": "Phi3VForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-3.5-vision-instruct",
+    "variant": "Phi-3.5-Vision",
+    "family": "phi",
+    "arch": "Phi3VForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-4-multimodal-instruct",
+    "variant": "Phi-4-multimodal",
+    "family": "phi",
+    "arch": "Phi4MMForCausalLM"
+  },
+  {
+    "model": "microsoft/Phi-4-reasoning-vision-15B",
+    "variant": "Phi-4-reasoning-vision",
+    "family": "phi",
+    "arch": "Phi4ForCausalLMV"
+  },
+  {
+    "model": "baidu/Qianfan-OCR",
+    "variant": "QianfanOCR",
+    "family": "qianfanocr",
+    "arch": "QianfanOCRForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen-VL",
+    "variant": "Qwen-VL",
+    "family": "qwen",
+    "arch": "QwenVLForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen2-Audio-7B-Instruct",
+    "variant": "Qwen2-Audio",
+    "family": "qwen",
+    "arch": "Qwen2AudioForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/QVQ-72B-Preview",
+    "variant": "QVQ",
+    "family": "qvq",
+    "arch": "Qwen2VLForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen2-VL-7B-Instruct",
+    "variant": "Qwen2-VL",
+    "family": "qwen",
+    "arch": "Qwen2VLForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+    "variant": "Qwen2.5-VL",
+    "family": "qwen",
+    "arch": "`Qwen2_5_VLForConditionalGeneration` <sup>Q</sup>"
+  },
+  {
+    "model": "Qwen/Qwen2.5-Omni-3B",
+    "variant": "Qwen2.5-Omni",
+    "family": "qwen",
+    "arch": "`Qwen2_5OmniThinkerForConditionalGeneration`"
+  },
+  {
+    "model": "Qwen/Qwen3.5-9B-Instruct",
+    "variant": "Qwen3.5",
+    "family": "qwen",
+    "arch": "`Qwen3_5ForConditionalGeneration`"
+  },
+  {
+    "model": "Qwen/Qwen3.5-35B-A3B-Instruct",
+    "variant": "Qwen3.5-MOE",
+    "family": "qwen",
+    "arch": "`Qwen3_5MoeForConditionalGeneration`"
+  },
+  {
+    "model": "Qwen/Qwen3-VL-4B-Instruct",
+    "variant": "Qwen3-VL",
+    "family": "qwen",
+    "arch": "Qwen3VLForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+    "variant": "Qwen3-VL-MOE",
+    "family": "qwen",
+    "arch": "Qwen3VLMoeForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    "variant": "Qwen3-Omni",
+    "family": "qwen",
+    "arch": "Qwen3OmniMoeThinkerForConditionalGeneration"
+  },
+  {
+    "model": "Qwen/Qwen3-ASR-1.7B",
+    "variant": "Qwen3-ASR",
+    "family": "qwen",
+    "arch": "Qwen3ASRForConditionalGeneration"
+  },
+  {
+    "model": "YannQi/R-4B",
+    "variant": "R-VL-4B",
+    "family": "r",
+    "arch": "RForConditionalGeneration"
+  },
+  {
+    "model": "Skywork/Skywork-R1V-38B",
+    "variant": "Skywork-R1V-38B",
+    "family": "skywork",
+    "arch": "SkyworkR1VChatModel"
+  },
+  {
+    "model": "stepfun-ai/step3",
+    "variant": "Step3-VL",
+    "family": "step",
+    "arch": "Step3VLForConditionalGeneration"
+  },
+  {
+    "model": "stepfun-ai/Step3-VL-10B",
+    "variant": "Step3-VL-10B",
+    "family": "step",
+    "arch": "StepVLForConditionalGeneration"
+  },
+  {
+    "model": "stepfun-ai/Step-3.7-Flash",
+    "variant": "Step-3.7-Flash",
+    "family": "step",
+    "arch": "Step3p7ForConditionalGeneration"
+  },
+  {
+    "model": "omni-search/Tarsier-7b",
+    "variant": "Tarsier",
+    "family": "tarsier",
+    "arch": "TarsierForConditionalGeneration"
+  },
+  {
+    "model": "omni-research/Tarsier2-Recap-7b",
+    "variant": "Tarsier2",
+    "family": "tarsier",
+    "arch": "Tarsier2ForConditionalGeneration"
+  },
+  {
+    "model": "fixie-ai/ultravox-v0_5-llama-3_2-1b",
+    "variant": "Ultravox",
+    "family": "ultravox",
+    "arch": "UltravoxModel"
+  },
+  {
+    "model": "BAAI/Emu3-Chat-hf",
+    "variant": "Emu3",
+    "family": "emu",
+    "arch": "Emu3ForConditionalGeneration"
+  },
+  {
+    "model": "CohereLabs/cohere-transcribe-03-2026",
+    "variant": "Cohere-Transcribe",
+    "family": "cohere",
+    "arch": "CohereAsrForConditionalGeneration"
+  },
+  {
+    "model": "allendou/FireRedASR2-LLM-vllm",
+    "variant": "FireRedASR2",
+    "family": "fireredasr",
+    "arch": "FireRedASR2ForConditionalGeneration"
+  },
+  {
+    "model": "PatchyTisa/FireRedLID-vllm",
+    "variant": "FireRedLID",
+    "family": "fireredlid",
+    "arch": "FireRedLIDForConditionalGeneration"
+  },
+  {
+    "model": "allendou/Fun-ASR-Nano-2512-vllm",
+    "variant": "FunASR",
+    "family": "funasr",
+    "arch": "FunASRForConditionalGeneration"
+  },
+  {
+    "model": "zai-org/GLM-ASR-Nano-2512",
+    "variant": "GLM-ASR",
+    "family": "glm",
+    "arch": "GlmAsrForConditionalGeneration"
+  },
+  {
+    "model": "ibm-granite/granite-speech-3.3-2b",
+    "variant": "Granite Speech",
+    "family": "granite",
+    "arch": "GraniteSpeechForConditionalGeneration"
+  },
+  {
+    "model": "mistralai/Voxtral-Mini-3B-2507",
+    "variant": "Voxtral (Mistral format)",
+    "family": "voxtral",
+    "arch": "VoxtralForConditionalGeneration"
+  },
+  {
+    "model": "openai/whisper-small",
+    "variant": "Whisper",
+    "family": "whisper",
+    "arch": "WhisperForConditionalGeneration"
+  },
+  {
+    "model": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+    "variant": "Voxtral Realtime",
+    "family": "voxtral",
+    "arch": "VoxtralRealtimeGeneration"
+  },
+  {
+    "model": "Qwen/Qwen3-ASR-0.6B",
+    "variant": "Qwen3-ASR Realtime",
+    "family": "qwen",
+    "arch": "Qwen3ASRRealtimeGeneration"
+  }
+]

--- a/ci_scripts/eager/vlm_models_v0.23.0.json
+++ b/ci_scripts/eager/vlm_models_v0.23.0.json
@@ -14,7 +14,7 @@
   {
     "model": "CohereLabs/aya-vision-8b",
     "variant": "Aya Vision",
-    "family": "aya",
+    "family": "ayavision",
     "arch": "AyaVisionForConditionalGeneration"
   },
   {
@@ -62,19 +62,19 @@
   {
     "model": "deepseek-ai/deepseek-vl2-tiny",
     "variant": "DeepSeek-VL2",
-    "family": "deepseek",
+    "family": "deepseekvl",
     "arch": "DeepseekVLV2ForCausalLM"
   },
   {
     "model": "deepseek-ai/DeepSeek-OCR",
     "variant": "DeepSeek-OCR",
-    "family": "deepseek",
+    "family": "deepseekocr",
     "arch": "DeepseekOCRForCausalLM"
   },
   {
     "model": "deepseek-ai/DeepSeek-OCR-2",
     "variant": "DeepSeek-OCR-2",
-    "family": "deepseek",
+    "family": "deepseekocr",
     "arch": "DeepseekOCR2ForCausalLM"
   },
   {
@@ -146,7 +146,7 @@
   {
     "model": "zai-org/GLM-OCR",
     "variant": "GLM-OCR",
-    "family": "glm",
+    "family": "glmocr",
     "arch": "GlmOcrForConditionalGeneration"
   },
   {
@@ -158,31 +158,31 @@
   {
     "model": "ibm-granite/granite-speech-3.3-8b",
     "variant": "Granite Speech",
-    "family": "granite",
+    "family": "granitespeech",
     "arch": "GraniteSpeechForConditionalGeneration"
   },
   {
     "model": "ibm-granite/granite-speech-4.1-2b-plus",
     "variant": "Granite Speech Plus",
-    "family": "granite",
+    "family": "granitespeechplus",
     "arch": "GraniteSpeechPlusForConditionalGeneration"
   },
   {
     "model": "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B",
     "variant": "HyperCLOVAX-SEED-Vision-Instruct-3B",
-    "family": "hyperclovax",
+    "family": "hyperclovaxseedvisioninstruct",
     "arch": "HCXVisionForCausalLM"
   },
   {
     "model": "naver-hyperclovax/HyperCLOVAX-SEED-Think-32B",
     "variant": "HyperCLOVAX-SEED-Think-32B",
-    "family": "hyperclovax",
+    "family": "hyperclovaxseedthink",
     "arch": "HCXVisionV2ForCausalLM"
   },
   {
     "model": "h2oai/h2ovl-mississippi-800m",
     "variant": "H2OVL",
-    "family": "h",
+    "family": "hovl",
     "arch": "H2OVLChatModel"
   },
   {
@@ -248,7 +248,7 @@
   {
     "model": "OpenGVLab/Mono-InternVL-2B",
     "variant": "Mono-InternVL",
-    "family": "mono",
+    "family": "monointernvl",
     "arch": "InternVLChatModel"
   },
   {
@@ -266,19 +266,19 @@
   {
     "model": "Kwai-Keye/Keye-VL-8B-Preview",
     "variant": "Keye-VL-8B-Preview",
-    "family": "keye",
+    "family": "keyevl",
     "arch": "KeyeForConditionalGeneration"
   },
   {
     "model": "Kwai-Keye/Keye-VL-1_5-8B",
     "variant": "Keye-VL-1_5-8B",
-    "family": "keye",
+    "family": "keyevl",
     "arch": "`KeyeVL1_5ForConditionalGeneration`"
   },
   {
     "model": "moonshotai/Kimi-Audio-7B-Instruct",
     "variant": "Kimi-Audio",
-    "family": "kimi",
+    "family": "kimiaudio",
     "arch": "KimiAudioForConditionalGeneration"
   },
   {
@@ -290,13 +290,13 @@
   {
     "model": "moonshotai/Kimi-VL-A3B-Instruct",
     "variant": "Kimi-VL-A3B-Instruct",
-    "family": "kimi",
+    "family": "kimivl",
     "arch": "KimiVLForConditionalGeneration"
   },
   {
     "model": "moonshotai/Kimi-VL-A3B-Thinking",
     "variant": "Kimi-VL-A3B-Thinking",
-    "family": "kimi",
+    "family": "kimivl",
     "arch": "KimiVLForConditionalGeneration"
   },
   {
@@ -320,7 +320,7 @@
   {
     "model": "nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1",
     "variant": "Llama Nemotron Nano VL",
-    "family": "llama",
+    "family": "llamanemotronnanovl",
     "arch": "`Llama_Nemotron_Nano_VL`"
   },
   {
@@ -332,19 +332,19 @@
   {
     "model": "ibm-granite/granite-vision-3.3-2b",
     "variant": "Granite Vision",
-    "family": "granite",
+    "family": "granitevision",
     "arch": "LlavaNextForConditionalGeneration"
   },
   {
     "model": "llava-hf/LLaVA-NeXT-Video-7B-hf",
     "variant": "LLaVA-NeXT-Video",
-    "family": "llava",
+    "family": "llavanextvideo",
     "arch": "LlavaNextVideoForConditionalGeneration"
   },
   {
     "model": "llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
     "variant": "LLaVA-Onevision",
-    "family": "llava",
+    "family": "llavaonevision",
     "arch": "LlavaOnevisionForConditionalGeneration"
   },
   {
@@ -374,7 +374,7 @@
   {
     "model": "MiniMaxAI/MiniMax-VL-01",
     "variant": "MiniMax-VL",
-    "family": "minimax",
+    "family": "minimaxvl",
     "arch": "MiniMaxVL01ForConditionalGeneration"
   },
   {
@@ -422,7 +422,7 @@
   {
     "model": "FreedomIntelligence/openPangu-VL-7B",
     "variant": "openpangu-VL",
-    "family": "openpangu",
+    "family": "openpanguvl",
     "arch": "OpenPanguVLForConditionalGeneration"
   },
   {
@@ -464,7 +464,7 @@
   {
     "model": "PaddlePaddle/PaddleOCR-VL",
     "variant": "Paddle-OCR",
-    "family": "paddle",
+    "family": "paddleocr",
     "arch": "PaddleOCRVLForConditionalGeneration"
   },
   {
@@ -512,7 +512,7 @@
   {
     "model": "Qwen/Qwen-VL",
     "variant": "Qwen-VL",
-    "family": "qwen",
+    "family": "qwenvl",
     "arch": "QwenVLForConditionalGeneration"
   },
   {
@@ -584,7 +584,7 @@
   {
     "model": "YannQi/R-4B",
     "variant": "R-VL-4B",
-    "family": "r",
+    "family": "rvlb",
     "arch": "RForConditionalGeneration"
   },
   {
@@ -638,7 +638,7 @@
   {
     "model": "CohereLabs/cohere-transcribe-03-2026",
     "variant": "Cohere-Transcribe",
-    "family": "cohere",
+    "family": "coheretranscribe",
     "arch": "CohereAsrForConditionalGeneration"
   },
   {
@@ -662,13 +662,13 @@
   {
     "model": "zai-org/GLM-ASR-Nano-2512",
     "variant": "GLM-ASR",
-    "family": "glm",
+    "family": "glmasr",
     "arch": "GlmAsrForConditionalGeneration"
   },
   {
     "model": "ibm-granite/granite-speech-3.3-2b",
     "variant": "Granite Speech",
-    "family": "granite",
+    "family": "granitespeech",
     "arch": "GraniteSpeechForConditionalGeneration"
   },
   {
@@ -686,7 +686,7 @@
   {
     "model": "mistralai/Voxtral-Mini-4B-Realtime-2602",
     "variant": "Voxtral Realtime",
-    "family": "voxtral",
+    "family": "voxtralrealtime",
     "arch": "VoxtralRealtimeGeneration"
   },
   {

--- a/tests/e2e/test_fallback_ops.py
+++ b/tests/e2e/test_fallback_ops.py
@@ -1,0 +1,163 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+"""Fallback-ops coverage: does an ATen op with no registered QAIC dispatch-key
+kernel actually produce the "CPU fallback op: ..." lines
+ci_scripts/eager/fallback_parser.py greps for, and does that parser (plus
+parse_logs_to_excel.py's re-parsing of its printed output) correctly turn
+those lines into the stats dict the Excel summary is built from.
+
+The hardware test requires QAIC_DEBUG=1 and QAIC_VISIBLE_DEVICES (set to the
+same list as --device-id) to be exported in the shell *before* pytest is
+launched, e.g.:
+
+    QAIC_DEBUG=1 QAIC_VISIBLE_DEVICES=9 python -m pytest \
+        tests/e2e/test_fallback_ops.py --device-id 9
+
+Both are read once by torch_qaic the first time it's imported, and it gets
+imported during collection (tests/e2e/conftest.py's pytest_collection_modifyitems
+checks current_platform.is_aot_inference() for every item) -- long before this
+test's body runs. Setting either from inside the test function is too late:
+QAIC_VISIBLE_DEVICES silently falls back to the unrestricted device list
+(so "qaic:0" resolves to physical QID 0, not the device this test acquired
+from the pool) and QAIC_DEBUG's fallback logging never turns on at all.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import regex as re
+import torch
+
+_EAGER_DIR = Path(__file__).resolve().parents[2] / "ci_scripts" / "eager"
+
+
+def _load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, _EAGER_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fallback_parser = _load_module("fallback_parser", "fallback_parser.py")
+parse_logs_to_excel = _load_module("parse_logs_to_excel", "parse_logs_to_excel.py")
+
+# aten::std.correction has no QAIC dispatch-key kernel today, so it's a
+# reliable, minimal trigger for the dispatcher's CPU-fallback path. If a
+# future torch_qaic ever implements it natively, swap in another op that's
+# still unimplemented.
+_FALLBACK_OP = "aten::std.correction"
+
+# A synthetic stand-in for a real QAIC_DEBUG=1 sweep log: two hits of one op
+# and one hit of another, interleaved with unrelated output.
+_SAMPLE_LOG = """\
+Some unrelated startup line
+CPU fallback op: aten::std.correction, execution started.
+CPU fallback op: aten::std.correction, time elapsed (us): 422
+some other line
+CPU fallback op: aten::std.correction, execution started.
+CPU fallback op: aten::std.correction, time elapsed (us): 295
+CPU fallback op: aten::topk, execution started.
+CPU fallback op: aten::topk, time elapsed (us): 10
+"""
+
+
+def test_extract_fallback_ops_counts_and_sums_time(tmp_path):
+    log_file = tmp_path / "log_1_model_tp1.log"
+    log_file.write_text(_SAMPLE_LOG)
+
+    stats = fallback_parser.extract_fallback_ops(str(log_file))
+
+    assert dict(stats) == {
+        "aten::std.correction": {"tc": 2, "tt": 717},
+        "aten::topk": {"tc": 1, "tt": 10},
+    }
+
+
+def test_extract_fallback_ops_empty_log_returns_empty_dict(tmp_path):
+    log_file = tmp_path / "log_1_model_tp1.log"
+    log_file.write_text("no fallback lines here\njust normal output\n")
+
+    stats = fallback_parser.extract_fallback_ops(str(log_file))
+
+    assert dict(stats) == {}
+
+
+def test_parse_logs_to_excel_reads_back_fallback_parser_output(tmp_path, capsys):
+    """extract_fallback_ops' printed defaultdict repr must still be exactly
+    what parse_log_file's `defaultdict\\([^,]+,\\s*(\\{.*\\})\\)` regex expects."""
+    log_file = tmp_path / "log_1_model_tp1.log"
+    log_file.write_text(_SAMPLE_LOG)
+
+    fallback_parser.extract_fallback_ops(str(log_file))
+    printed = capsys.readouterr().out
+
+    parse_log = tmp_path / "parse_1_model_tp1.log"
+    parse_log.write_text(printed)
+
+    ops = parse_logs_to_excel.parse_log_file(str(parse_log))
+
+    assert ops == {
+        "aten::std.correction": {"tc": 2, "tt": 717},
+        "aten::topk": {"tc": 1, "tt": 10},
+    }
+
+
+class TestFallbackOps:
+    def test_unimplemented_op_logs_cpu_fallback(
+        self, capfd, tmp_path, device_group, device_pool_ids
+    ):
+        if (
+            os.environ.get("QAIC_DEBUG") != "1"
+            or "QAIC_VISIBLE_DEVICES" not in os.environ
+        ):
+            pytest.skip(
+                "requires QAIC_DEBUG=1 and QAIC_VISIBLE_DEVICES (matching "
+                "--device-id) exported before launching pytest -- see module "
+                "docstring"
+            )
+        pytest.importorskip("torch_qaic")
+
+        # QAIC_VISIBLE_DEVICES was fixed before this process started (see
+        # docstring), so "qaic:<local index>" addresses devices by position
+        # within that fixed list, not by physical QID.
+        local_idx = device_pool_ids.index(device_group[0])
+
+        x = torch.randn(8, 8, device=f"qaic:{local_idx}")
+        torch.qaic.synchronize()
+        capfd.readouterr()  # drop device-init/context-creation noise
+
+        x.std()
+        torch.qaic.synchronize()
+
+        captured = capfd.readouterr()
+        combined = captured.out + captured.err
+
+        assert re.search(
+            rf"CPU fallback op:\s*{re.escape(_FALLBACK_OP)},\s*execution started",
+            combined,
+        ), (
+            f"expected the QAIC runtime to log a CPU-fallback 'execution "
+            f"started' line for {_FALLBACK_OP}; captured output:\n{combined}"
+        )
+        assert re.search(
+            rf"CPU fallback op:\s*{re.escape(_FALLBACK_OP)},"
+            rf"\s*time elapsed \(us\):\s*\d+",
+            combined,
+        ), (
+            f"expected the QAIC runtime to log a CPU-fallback 'time elapsed' "
+            f"line for {_FALLBACK_OP}; captured output:\n{combined}"
+        )
+
+        # End-to-end: the real runtime output must also be consumable by our
+        # own parser, not just by this test's inline regex.
+        log_file = tmp_path / "log_1_direct_tp1.log"
+        log_file.write_text(combined)
+        stats = fallback_parser.extract_fallback_ops(str(log_file))
+        assert stats[_FALLBACK_OP]["tc"] >= 1
+        assert stats[_FALLBACK_OP]["tt"] > 0


### PR DESCRIPTION
Builds on #36 ("Add support for Fallback CI"). Includes those commits plus the following on top:

- `fallback_parser.extract_fallback_ops` now returns the stats dict instead of only printing it, so callers (and tests) can consume the parsed data directly instead of re-parsing stdout.
- `parse_logs_to_excel.build_sheet` gains a `Fallback?` Yes/No column ahead of the per-op breakdown, and the per-op sub-column construction is deduplicated via a single `SUB_COLUMNS` list.
- Add `tests/e2e/test_fallback_ops.py` covering fallback-op detection, parsing, and the parser/Excel-importer round trip end to end.
- Ignore `ci_scripts/ci_logs/`, the run-artifact directory these scripts write logs/csv/xlsx into.

## Example output

Sample rows from a `fallback_ops_summary.xlsx` run, showing the new `Fallback?` column and the per-op `Fallback Count` / `Total Time (us)` breakdown:

| Model | Ran? | Fallback? | TP | Op | Fallback Count | Total Time (us) |
|---|---|---|---|---|---|---|
| deepseek-ai_DeepSeek-OCR | No | Yes | 1 | aten::_upsample_bicubic2d_aa.out | 22 | 11,510,038 |
| | | | | aten::div.out | 22 | 2,514,405 |
| | | | | aten::mul.out | 2 | 890 |
| | | | | aten::pow.Tensor_Scalar_out | 22 | 3,597,961 |
| | | | | aten::upsample_linear1d.out | 88 | 6,679,830 |
| microsoft_Phi-3-vision-128k-instruct | Yes | Yes | 4 | aten::remainder.Scalar_Tensor | 20 | 10,917 |
| Qwen_Qwen2-Audio-7B-Instruct | No | Yes | 4 | aten::_index_put_impl_ | 4 | 407,435 |
| | | | | aten::avg_pool2d.out | 4 | 47,648,260 |
| | | | | aten::ge.Tensor_out | 4 | 5,109 |

`Ran?` reflects whether the model completed; `Fallback?` is `Yes` whenever any op fell back to CPU regardless of whether the run itself succeeded, which is what this PR's `extract_fallback_ops` return value now makes queryable in code (and covered by the new tests) instead of only visible in stdout.

## Test plan

- [x] Pre-commit (ruff, mypy, forbidden-imports, etc.) passes on all changed files.
- [x] Verified `extract_fallback_ops` / `parse_log_file` round-trip logic against a synthetic sample log.
- [x] Hardware-backed test (`TestFallbackOps::test_unimplemented_op_logs_cpu_fallback`) needs to be run on QAIC hardware with `QAIC_DEBUG=1` and `QAIC_VISIBLE_DEVICES` set — not runnable in this environment.
