### PR TITLE
Paged Attention AOT 

### DIFF
--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -600,6 +600,25 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 )
         return
 
+    def _inject_pa_prefill_inputs(
+        self,
+        chunk_inputs: dict,
+        batch_idx: int,
+        block_table: np.ndarray | None,
+        slot_id: np.ndarray | None,
+        req_index: int,
+    ) -> None:
+        if not self.paged_attention:
+            return
+        if block_table is not None and slot_id is not None:
+            chunk_inputs["block_table"] = block_table[
+                req_index : req_index + 1
+            ].reshape(1, self.num_gpu_blocks_per_batch)
+            chunk_inputs["slot_id"] = slot_id[req_index : req_index + 1]
+        else:
+            chunk_inputs["block_table"] = batch_idx
+            chunk_inputs["slot_id"] = 0
+
     def _run_pipeline_prefill(
         self,
         input_ids: np.ndarray,
@@ -713,17 +732,9 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     if logits is not None:
                         chunk_inputs["logits"] = logits[index : index + 1]
 
-                if self.paged_attention:
-                    if block_table is not None and slot_id is not None:
-                        req_block_table = block_table[index : index + 1].reshape(
-                            1, self.num_gpu_blocks_per_batch
-                        )
-                        chunk_inputs["block_table"] = req_block_table
-                        req_slot_id = slot_id[index : index + 1]
-                        chunk_inputs["slot_id"] = req_slot_id
-                    else:
-                        chunk_inputs["block_table"] = batch_index
-                        chunk_inputs["slot_id"] = 0
+                self._inject_pa_prefill_inputs(
+                    chunk_inputs, batch_index, block_table, slot_id, index
+                )
 
                 if pending_exec_count == self.session.prefill_num_execObj:
                     if callback:
@@ -816,17 +827,9 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 chunk_inputs["lora_ids"] = lora_index
             if mm_kwargs_list and (mm_kwargs := mm_kwargs_list[i]):
                 chunk_inputs.update(mm_kwargs)
-            if self.paged_attention:
-                if block_table is not None and slot_id is not None:
-                    req_block_table = block_table[i : i + 1].reshape(
-                        1, self.num_gpu_blocks_per_batch
-                    )
-                    chunk_inputs["block_table"] = req_block_table
-                    req_slot_id = slot_id[i : i + 1]
-                    chunk_inputs["slot_id"] = req_slot_id
-                else:
-                    chunk_inputs["block_table"] = batch_index
-                    chunk_inputs["slot_id"] = 0
+            self._inject_pa_prefill_inputs(
+                chunk_inputs, batch_indices[i], block_table, slot_id, i
+            )
             # chunk the request
             n_chunks: int = iids.shape[-1] // self.prefill_seq_len
 

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -938,20 +938,16 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
 
         if self.paged_attention:
             if block_table is not None and slot_id is not None:
-                self.decode_batch_inputs["block_table"][:num_decodes] = block_table[
-                    :num_decodes
-                ]
-                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[
-                    :num_decodes
-                ]
+                batch_inputs["block_table"][:num_decodes] = block_table[:num_decodes]
+                batch_inputs["slot_id"][:num_decodes] = slot_id[:num_decodes]
                 if num_decodes < self.decode_bsz:
-                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
-                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
+                    batch_inputs["block_table"][num_decodes:] = -1
+                    batch_inputs["slot_id"][num_decodes:] = 0
             else:
-                self.decode_batch_inputs["block_table"][:num_decodes] = batch_indices
+                batch_inputs["block_table"][:num_decodes] = batch_indices
                 if num_decodes < self.decode_bsz:
-                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
-                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
+                    batch_inputs["block_table"][num_decodes:] = -1
+                    batch_inputs["slot_id"][num_decodes:] = 0
 
         # For spec-decode target: include num_logits_to_keep in batch_inputs
         # so the hardware knows how many token positions to compute logits for.

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -148,13 +148,12 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
-        self.num_gpu_blocks_per_batch = self.ctx_len // vllm_config.cache_config.block_size
+        # block_size may be None here (vLLM v1 populates it after
+        # determine_num_available_blocks); deferred to load_model.
+        self._vllm_config = vllm_config
+        self.num_gpu_blocks_per_batch = None  # set in load_model
         if vllm_config.cache_config.enable_prefix_caching:
-            self.num_gpu_blocks = (
-                vllm_config.cache_config.num_gpu_blocks_override
-                if vllm_config.cache_config.num_gpu_blocks_override
-                else self.ctx_len // vllm_config.cache_config.block_size
-            )
+            self.num_gpu_blocks = None  # set in load_model
         else:
             self.num_gpu_blocks = self.decode_bsz
         self.paged_attention = bool(vllm_config.cache_config.enable_prefix_caching)
@@ -381,6 +380,18 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.disagg_serving_en = kv_transfer_role is not None
         self.disagg_producer_en = kv_transfer_role == "kv_producer"
 
+        # block_size is now populated (set during cache initialisation)
+        cache_config = self._vllm_config.cache_config
+        self.num_gpu_blocks_per_batch = self.ctx_len // cache_config.block_size
+        if self.paged_attention:
+            self.num_gpu_blocks = (
+                cache_config.num_gpu_blocks_override
+                if cache_config.num_gpu_blocks_override
+                else self.ctx_len // cache_config.block_size
+            )
+        else:
+            self.num_gpu_blocks = self.decode_bsz
+
         logger.info("Loading QPC...")
         logger.info(
             "This may take some time, please don't press CTRL-C during this phase..."
@@ -393,10 +404,20 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             self.stages = 1
         from .qaic_session_np import QAICInferenceSession
 
+        # qaicrt uses virtual device IDs (0-based within QAIC_VISIBLE_DEVICES).
+        # Translate physical device IDs to virtual IDs before creating the session.
+        _visible = os.environ.get(current_platform.device_control_env_var)
+        if _visible is not None:
+            _visible_ids = [int(x) for x in _visible.replace(",", " ").split()]
+            _phys_to_virt = {phys: virt for virt, phys in enumerate(_visible_ids)}
+            session_device_ids = [_phys_to_virt.get(d, d) for d in device_id]
+        else:
+            session_device_ids = device_id
+
         self.session = QAICInferenceSession(
             qpc_path,
             full_batch_size=self.full_batch_size,
-            device_ids=device_id,
+            device_ids=session_device_ids,
             stages=self.stages,
             cluster_id=cluster_id,
             use_async_scheduling=self.use_async_scheduling,
@@ -925,7 +946,9 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 self.decode_batch_inputs["block_table"][:num_decodes] = block_table[
                     :num_decodes
                 ]
-                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[:num_decodes]
+                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[
+                    :num_decodes
+                ]
                 if num_decodes < self.decode_bsz:
                     self.decode_batch_inputs["block_table"][num_decodes:] = -1
                     self.decode_batch_inputs["slot_id"][num_decodes:] = 0
@@ -1968,10 +1991,22 @@ def _get_qaic_compile_config(
         from qaicrt import QStatus
 
         if cfg["device_group"] is not None:
+            # qaicrt uses virtual device IDs (0-based within QAIC_VISIBLE_DEVICES).
+            # Physical device IDs from device_group must be translated to virtual
+            # IDs before calling getResourceInfo.
+            _visible = os.environ.get(current_platform.device_control_env_var)
+            if _visible is not None:
+                _visible_ids = [int(x) for x in _visible.replace(",", " ").split()]
+                _phys_to_virt = {phys: virt for virt, phys in enumerate(_visible_ids)}
+            else:
+                _phys_to_virt = {}
             for id in cfg["device_group"]:
-                _nsp_info = qaic_util().getResourceInfo(id)
+                virt_id = _phys_to_virt.get(id, id)
+                _nsp_info = qaic_util().getResourceInfo(virt_id)
                 if _nsp_info[0] != QStatus.QS_SUCCESS:
-                    raise ValueError(f"device_id {id} is not available !!")
+                    raise ValueError(
+                        f"device_id {id} (virtual {virt_id}) is not available !!"
+                    )
                 _hw_num_cores = min(_hw_num_cores, _nsp_info[1].nspTotal)
         cfg["num_cores"] = _hw_num_cores
         # Applicable for draft-target spd scheme
@@ -2140,15 +2175,18 @@ def _get_qaic_compile_config(
     # off between producer and consumer stay aligned. Written here, before
     # get_kv_cache_spec() is queried, so the updated value is picked up when
     # the KV cache is sized.
-    if vllm_config.kv_transfer_config:
-        vllm_config.cache_config.block_size = cfg["kv_block_size"]
-    else:
-        vllm_config.cache_config.block_size = cfg["prefill_seq_len"]
 
-    # Add num_kv_blocks through qaic_config
-    num_kv_blocks = vllm_config.model_config.max_model_len // vllm_config.cache_config.block_size
-    logger.info("Num KV Blocks: %s", num_kv_blocks)
     if vllm_config.cache_config.enable_prefix_caching:
+        # Add num_kv_blocks through qaic_config
+        if vllm_config.kv_transfer_config:
+            num_kv_blocks = (
+                vllm_config.model_config.max_model_len // cfg["kv_block_size"]
+            )
+        else:
+            num_kv_blocks = (
+                vllm_config.model_config.max_model_len // cfg["prefill_seq_len"]
+            )
+        logger.info("Num KV Blocks: %s", num_kv_blocks)
         qaic_config["num_kv_blocks"] = num_kv_blocks
         qaic_config["blocking_mode"] = "kv_paged"
         qaic_config["enable_blocking"] = True

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -148,12 +148,12 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
-        self.num_gpu_blocks_per_batch = self.ctx_len // self.prefill_seq_len
+        self.num_gpu_blocks_per_batch = self.ctx_len // vllm_config.cache_config.block_size
         if vllm_config.cache_config.enable_prefix_caching:
             self.num_gpu_blocks = (
                 vllm_config.cache_config.num_gpu_blocks_override
                 if vllm_config.cache_config.num_gpu_blocks_override
-                else self.ctx_len // self.prefill_seq_len
+                else self.ctx_len // vllm_config.cache_config.block_size
             )
         else:
             self.num_gpu_blocks = self.decode_bsz
@@ -2134,17 +2134,22 @@ def _get_qaic_compile_config(
                 if (len(cfg.get("comp_ctx_lengths_decode", [])) == 0)
                 else cfg.get("comp_ctx_lengths_decode")
             )
+    # For disaggregated serving, the KV cache block size must match the
+    # prefill chunk size actually compiled into the QPC (post-override), not
+    # just the scheduler's long_prefill_token_threshold, so KV blocks handed
+    # off between producer and consumer stay aligned. Written here, before
+    # get_kv_cache_spec() is queried, so the updated value is picked up when
+    # the KV cache is sized.
+    if vllm_config.kv_transfer_config:
+        vllm_config.cache_config.block_size = cfg["kv_block_size"]
+    else:
+        vllm_config.cache_config.block_size = cfg["prefill_seq_len"]
+
     # Add num_kv_blocks through qaic_config
-    logger.info(
-        "Num KV Blocks: %s",
-        vllm_config.model_config.max_model_len
-        // vllm_config.scheduler_config.long_prefill_token_threshold,
-    )
+    num_kv_blocks = vllm_config.model_config.max_model_len // vllm_config.cache_config.block_size
+    logger.info("Num KV Blocks: %s", num_kv_blocks)
     if vllm_config.cache_config.enable_prefix_caching:
-        qaic_config["num_kv_blocks"] = (
-            vllm_config.model_config.max_model_len
-            // vllm_config.scheduler_config.long_prefill_token_threshold
-        )
+        qaic_config["num_kv_blocks"] = num_kv_blocks
         qaic_config["blocking_mode"] = "kv_paged"
         qaic_config["enable_blocking"] = True
     else:

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -148,6 +148,16 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
+        self.num_gpu_blocks_per_batch = self.ctx_len // self.prefill_seq_len
+        if vllm_config.cache_config.enable_prefix_caching:
+            self.num_gpu_blocks = (
+                vllm_config.cache_config.num_gpu_blocks_override
+                if vllm_config.cache_config.num_gpu_blocks_override
+                else self.ctx_len // self.prefill_seq_len
+            )
+        else:
+            self.num_gpu_blocks = self.decode_bsz
+        self.paged_attention = bool(vllm_config.cache_config.enable_prefix_caching)
         self.prefill_bsz = 1
         self.lora_mode = bool(vllm_config.lora_config)
         self.last_decode = False
@@ -219,6 +229,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         prefill_is_partial: list[bool] | None = None,
         prefill_cum_sum: np.ndarray | None = None,
         logits: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         num_prompt_tokens_prefill: np.ndarray | None = None,
     ) -> Queue | None:
         if self.is_pooling_model and not self.is_multimodal_model:
@@ -241,6 +253,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     callback,
                     mm_kwargs_list,
                     logits,
+                    block_table,
+                    slot_id,
                     num_prompt_tokens_prefill,
                 )
                 return pending_prefill_exec_queue
@@ -259,6 +273,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                         logits,
                         lora_ids,
                         mm_kwargs_list,
+                        block_table,
+                        slot_id,
                     )
                     return pending_prefill_exec_queue
                 else:
@@ -268,7 +284,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                         batch_indices,
                         logits,
                         lora_ids,
-                        callback=callback,
+                        block_table,
+                        slot_id,
                     )
         return None
 
@@ -392,6 +409,14 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.logits_dtype = (
             np.dtype(_logits_info[1]) if _logits_info is not None else np.float32
         )
+
+        if "block_table" in self.session.input_names:
+            self.decode_batch_inputs["block_table"] = np.full(
+                (self.decode_bsz, self.num_gpu_blocks_per_batch), -1, dtype=np.int64
+            )
+            self.decode_batch_inputs["slot_id"] = np.full(
+                (self.decode_bsz,), 0, dtype=np.int64
+            )
 
         e = time.perf_counter() - s
         logger.info("Successfully loaded QPC in %s secs", e)
@@ -569,6 +594,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         callback: Callable | None = None,
         mm_kwargs_list: list[dict] | None = None,
         logits: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         num_prompt_tokens_prefill: np.ndarray | None = None,
     ):
         pending_exec_count = 0  # in-flight executions in current batch
@@ -667,6 +694,18 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     if logits is not None:
                         chunk_inputs["logits"] = logits[index : index + 1]
 
+                if self.paged_attention:
+                    if block_table is not None and slot_id is not None:
+                        req_block_table = block_table[index : index + 1].reshape(
+                            1, self.num_gpu_blocks_per_batch
+                        )
+                        chunk_inputs["block_table"] = req_block_table
+                        req_slot_id = slot_id[index : index + 1]
+                        chunk_inputs["slot_id"] = req_slot_id
+                    else:
+                        chunk_inputs["block_table"] = batch_index
+                        chunk_inputs["slot_id"] = 0
+
                 if pending_exec_count == self.session.prefill_num_execObj:
                     if callback:
                         callback()
@@ -714,6 +753,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         logits: np.ndarray,
         lora_ids: np.ndarray | None = None,
         mm_kwargs_list: list[dict] | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
     ) -> np.ndarray:
         # perform prefill (only prefill_bsz=1 is supported)
         pending_exec_count = 0  # in-flight executions in current batch
@@ -756,6 +797,17 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 chunk_inputs["lora_ids"] = lora_index
             if mm_kwargs_list and (mm_kwargs := mm_kwargs_list[i]):
                 chunk_inputs.update(mm_kwargs)
+            if self.paged_attention:
+                if block_table is not None and slot_id is not None:
+                    req_block_table = block_table[i : i + 1].reshape(
+                        1, self.num_gpu_blocks_per_batch
+                    )
+                    chunk_inputs["block_table"] = req_block_table
+                    req_slot_id = slot_id[i : i + 1]
+                    chunk_inputs["slot_id"] = req_slot_id
+                else:
+                    chunk_inputs["block_table"] = batch_index
+                    chunk_inputs["slot_id"] = 0
             # chunk the request
             n_chunks: int = iids.shape[-1] // self.prefill_seq_len
 
@@ -832,6 +884,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         batch_indices: np.ndarray,
         logits: np.ndarray,
         lora_ids: np.ndarray | None = None,
+        block_table: np.ndarray | None = None,
+        slot_id: np.ndarray | None = None,
         callback: Callable | None = None,
     ) -> None:
         # Use the per-step K set by QaicModelRunner.  Falls back to max K so
@@ -865,6 +919,21 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
             batch_inputs["lora_ids"][:num_decodes] = lora_ids.reshape(num_decodes, 1)
             if num_decodes < self.decode_bsz:
                 batch_inputs["lora_ids"][num_decodes:] = -1
+
+        if self.paged_attention:
+            if block_table is not None and slot_id is not None:
+                self.decode_batch_inputs["block_table"][:num_decodes] = block_table[
+                    :num_decodes
+                ]
+                self.decode_batch_inputs["slot_id"][:num_decodes] = slot_id[:num_decodes]
+                if num_decodes < self.decode_bsz:
+                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
+                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
+            else:
+                self.decode_batch_inputs["block_table"][:num_decodes] = batch_indices
+                if num_decodes < self.decode_bsz:
+                    self.decode_batch_inputs["block_table"][num_decodes:] = -1
+                    self.decode_batch_inputs["slot_id"][num_decodes:] = 0
 
         # For spec-decode target: include num_logits_to_keep in batch_inputs
         # so the hardware knows how many token positions to compute logits for.
@@ -2019,10 +2088,10 @@ def _get_qaic_compile_config(
         if qaic_config is None:
             qaic_config = {}
         qaic_config["speculative_model_type"] = speculative_model_type
+    if qaic_config is None:
+        qaic_config = dict()
     # On Device Sampling
     if cfg.get("aic_include_sampler") is not None:
-        if qaic_config is None:
-            qaic_config = dict()
         qaic_config["include_sampler"] = cfg["aic_include_sampler"]
         if cfg.get("aic_return_pdfs") is not None:
             qaic_config["return_pdfs"] = cfg["aic_return_pdfs"]
@@ -2053,8 +2122,6 @@ def _get_qaic_compile_config(
         or len(cfg.get("comp_ctx_lengths_prefill", [])) > 0
         or len(cfg.get("comp_ctx_lengths_decode", [])) > 0
     ):
-        if qaic_config is None:
-            qaic_config = dict()
         qaic_config["ccl_enabled"] = True
         if not cfg.pop("ccl_enabled", False):
             cfg["comp_ctx_lengths_prefill"] = (
@@ -2067,6 +2134,22 @@ def _get_qaic_compile_config(
                 if (len(cfg.get("comp_ctx_lengths_decode", [])) == 0)
                 else cfg.get("comp_ctx_lengths_decode")
             )
+    # Add num_kv_blocks through qaic_config
+    logger.info(
+        "Num KV Blocks: %s",
+        vllm_config.model_config.max_model_len
+        // vllm_config.scheduler_config.long_prefill_token_threshold,
+    )
+    if vllm_config.cache_config.enable_prefix_caching:
+        qaic_config["num_kv_blocks"] = (
+            vllm_config.model_config.max_model_len
+            // vllm_config.scheduler_config.long_prefill_token_threshold
+        )
+        qaic_config["blocking_mode"] = "kv_paged"
+        qaic_config["enable_blocking"] = True
+    else:
+        qaic_config["blocking_mode"] = ""
+        qaic_config["enable_blocking"] = False
     qpc_path = cfg.pop("qpc_path")
     if qpc_path and kv_offload and len(qpc_path.split(":")) > 1:
         assert qpc_idx is not None

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -148,13 +148,8 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
-        self._vllm_config = vllm_config
-        self.num_gpu_blocks_per_batch = None
-        if vllm_config.cache_config.enable_prefix_caching:
-            self.num_gpu_blocks = None
-        else:
-            self.num_gpu_blocks = self.decode_bsz
         self.paged_attention = bool(vllm_config.cache_config.enable_prefix_caching)
+        self._cache_config = vllm_config.cache_config
         self.prefill_bsz = 1
         self.lora_mode = bool(vllm_config.lora_config)
         self.last_decode = False
@@ -377,15 +372,14 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.stages: int = stages if stages is not None else 1
         self.disagg_serving_en = kv_transfer_role is not None
         self.disagg_producer_en = kv_transfer_role == "kv_producer"
-
-        # block_size is now populated (set during cache initialisation)
-        cache_config = self._vllm_config.cache_config
-        self.num_gpu_blocks_per_batch = self.ctx_len // cache_config.block_size
+        self.num_gpu_blocks_per_batch = cdiv(
+            self.ctx_len, self._cache_config.block_size
+        )
         if self.paged_attention:
             self.num_gpu_blocks = (
-                cache_config.num_gpu_blocks_override
-                if cache_config.num_gpu_blocks_override
-                else self.ctx_len // cache_config.block_size
+                self._cache_config.num_gpu_blocks_override
+                if self._cache_config.num_gpu_blocks_override
+                else cdiv(self.ctx_len, self._cache_config.block_size)
             )
         else:
             self.num_gpu_blocks = self.decode_bsz
@@ -2180,13 +2174,13 @@ def _get_qaic_compile_config(
     if vllm_config.cache_config.enable_prefix_caching:
         # Add num_kv_blocks through qaic_config
         if vllm_config.kv_transfer_config:
-            num_kv_blocks = (
-                vllm_config.model_config.max_model_len // cfg["kv_block_size"]
+            num_kv_blocks = cdiv(
+                vllm_config.model_config.max_model_len, cfg["kv_block_size"]
             )
             vllm_config.cache_config.block_size = cfg["kv_block_size"]
         else:
-            num_kv_blocks = (
-                vllm_config.model_config.max_model_len // cfg["prefill_seq_len"]
+            num_kv_blocks = cdiv(
+                vllm_config.model_config.max_model_len, cfg["prefill_seq_len"]
             )
             vllm_config.cache_config.block_size = cfg["prefill_seq_len"]
         logger.info("Num KV Blocks: %s", num_kv_blocks)

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -148,12 +148,10 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.ctx_len = model_config.max_model_len
         self.decode_bsz = vllm_config.scheduler_config.max_num_seqs
         self.full_batch_size = vllm_config.scheduler_config.max_num_seqs
-        # block_size may be None here (vLLM v1 populates it after
-        # determine_num_available_blocks); deferred to load_model.
         self._vllm_config = vllm_config
-        self.num_gpu_blocks_per_batch = None  # set in load_model
+        self.num_gpu_blocks_per_batch = None
         if vllm_config.cache_config.enable_prefix_caching:
-            self.num_gpu_blocks = None  # set in load_model
+            self.num_gpu_blocks = None
         else:
             self.num_gpu_blocks = self.decode_bsz
         self.paged_attention = bool(vllm_config.cache_config.enable_prefix_caching)
@@ -2182,10 +2180,12 @@ def _get_qaic_compile_config(
             num_kv_blocks = (
                 vllm_config.model_config.max_model_len // cfg["kv_block_size"]
             )
+            vllm_config.cache_config.block_size = cfg["kv_block_size"]
         else:
             num_kv_blocks = (
                 vllm_config.model_config.max_model_len // cfg["prefill_seq_len"]
             )
+            vllm_config.cache_config.block_size = cfg["prefill_seq_len"]
         logger.info("Num KV Blocks: %s", num_kv_blocks)
         qaic_config["num_kv_blocks"] = num_kv_blocks
         qaic_config["blocking_mode"] = "kv_paged"

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -2174,10 +2174,9 @@ def _get_qaic_compile_config(
     if vllm_config.cache_config.enable_prefix_caching:
         # Add num_kv_blocks through qaic_config
         if vllm_config.kv_transfer_config:
-            num_kv_blocks = cdiv(
-                vllm_config.model_config.max_model_len, cfg["kv_block_size"]
-            )
-            vllm_config.cache_config.block_size = cfg["kv_block_size"]
+            kv_block_size = cfg.pop("kv_block_size")
+            num_kv_blocks = cdiv(vllm_config.model_config.max_model_len, kv_block_size)
+            vllm_config.cache_config.block_size = kv_block_size
         else:
             num_kv_blocks = cdiv(
                 vllm_config.model_config.max_model_len, cfg["prefill_seq_len"]

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -301,16 +301,25 @@ class QaicPlatform(Platform):
                 cache_config.block_size = 16
             else:
                 if cache_config.enable_prefix_caching:
-                    cache_config.enable_prefix_caching = False
                     cache_config.mamba_block_size = (
                         model_config.max_model_len
                     )  # reset to "no-op" default
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
-                    logger.warning_once(
-                        "Prefix caching is not yet supported on v1 Engine. "
-                        "Will automatically disable it."
+                    cache_config.block_size = (
+                        scheduler_config.long_prefill_token_threshold
                     )
-                cache_config.block_size = model_config.max_model_len  # ctx_len
+                elif model_config.is_multimodal_model and model_config.is_encoder_decoder:
+                    cache_config.block_size = 100000
+                else:
+                    cache_config.block_size = model_config.max_model_len  # ctx_len
+
+        # disable async scheduling since Qaic does not yet support it
+        if scheduler_config.async_scheduling:
+            logger.warning(
+                "QAIC currently does not support async scheduling; "
+                "Falling back to non-async scheduling."
+            )
+            scheduler_config.async_scheduling = False
 
         if cls.is_aot:
             if model_config.hf_config.model_type == "whisper":
@@ -539,6 +548,9 @@ class QaicPlatform(Platform):
                 scheduler_config.max_num_seqs
                 * scheduler_config.long_prefill_token_threshold
             )
+            cache_config = vllm_config.cache_config
+            if cache_config and cache_config.enable_prefix_caching:
+                cache_config.block_size = scheduler_config.long_prefill_token_threshold
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -305,14 +305,7 @@ class QaicPlatform(Platform):
                         model_config.max_model_len
                     )  # reset to "no-op" default
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
-                    if vllm_config.kv_transfer_config:
-                        cache_config.block_size = vllm_config.additional_config.get(
-                            "override_qaic_config", {}
-                        ).get("kv_block_size")
-                    else:
-                        cache_config.block_size = vllm_config.additional_config.get(
-                            "override_qaic_config", {}
-                        ).get("prefill_seq_len")
+                    cache_config.block_size = cls._pa_block_size(vllm_config)
                 elif (
                     model_config.is_multimodal_model and model_config.is_encoder_decoder
                 ):
@@ -474,6 +467,13 @@ class QaicPlatform(Platform):
                 )
 
     @classmethod
+    def _pa_block_size(cls, vllm_config) -> int:
+        override = vllm_config.additional_config.get("override_qaic_config", {})
+        if vllm_config.kv_transfer_config:
+            return override.get("kv_block_size")
+        return override.get("prefill_seq_len")
+
+    @classmethod
     def is_pin_memory_available(cls) -> bool:
         logger.warning("Pin memory is not supported on Qaic.")
         return False
@@ -548,16 +548,11 @@ class QaicPlatform(Platform):
                 scheduler_config.max_num_seqs
                 * scheduler_config.long_prefill_token_threshold
             )
-            cache_config = vllm_config.cache_config
-            if cache_config and cache_config.enable_prefix_caching:
-                if vllm_config.kv_transfer_config:
-                    cache_config.block_size = vllm_config.additional_config.get(
-                        "override_qaic_config", {}
-                    ).get("kv_block_size")
-                else:
-                    cache_config.block_size = vllm_config.additional_config.get(
-                        "override_qaic_config", {}
-                    ).get("prefill_seq_len")
+            if (
+                vllm_config.cache_config
+                and vllm_config.cache_config.enable_prefix_caching
+            ):
+                vllm_config.cache_config.block_size = cls._pa_block_size(vllm_config)
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -305,10 +305,17 @@ class QaicPlatform(Platform):
                         model_config.max_model_len
                     )  # reset to "no-op" default
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
-                    cache_config.block_size = (
-                        vllm_config.additional_config.get("prefill_seq_len")
-                    )
-                elif model_config.is_multimodal_model and model_config.is_encoder_decoder:
+                    if vllm_config.kv_transfer_config:
+                        cache_config.block_size = vllm_config.additional_config.get(
+                            "kv_block_size"
+                        )
+                    else:
+                        cache_config.block_size = vllm_config.additional_config.get(
+                            "prefill_seq_len"
+                        )
+                elif (
+                    model_config.is_multimodal_model and model_config.is_encoder_decoder
+                ):
                     cache_config.block_size = 100000
                 else:
                     cache_config.block_size = model_config.max_model_len  # ctx_len
@@ -431,13 +438,6 @@ class QaicPlatform(Platform):
                 "serving, other SPD types such as Turbo is not yet supported "
                 "with Disaggregated serving for QAIC backend"
             )
-            assert not (
-                vllm_config.kv_transfer_config.kv_role != "kv_producer"
-                and vllm_config.cache_config.enable_prefix_caching
-            ), (
-                "Prefix caching with KV-role 'kv_consumer' or 'kv_both' not "
-                "yet supported for QAIC backend"
-            )
             if (
                 on_device_sampling_en
                 and vllm_config.kv_transfer_config.kv_role == "kv_producer"
@@ -550,7 +550,14 @@ class QaicPlatform(Platform):
             )
             cache_config = vllm_config.cache_config
             if cache_config and cache_config.enable_prefix_caching:
-                cache_config.block_size = vllm_config.additional_config.get("prefill_seq_len")
+                if vllm_config.kv_transfer_config:
+                    cache_config.block_size = vllm_config.additional_config.get(
+                        "kv_block_size"
+                    )
+                else:
+                    cache_config.block_size = vllm_config.additional_config.get(
+                        "prefill_seq_len"
+                    )
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -307,12 +307,12 @@ class QaicPlatform(Platform):
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
                     if vllm_config.kv_transfer_config:
                         cache_config.block_size = vllm_config.additional_config.get(
-                            "kv_block_size"
-                        )
+                            "override_qaic_config", {}
+                        ).get("kv_block_size")
                     else:
                         cache_config.block_size = vllm_config.additional_config.get(
-                            "prefill_seq_len"
-                        )
+                            "override_qaic_config", {}
+                        ).get("prefill_seq_len")
                 elif (
                     model_config.is_multimodal_model and model_config.is_encoder_decoder
                 ):
@@ -552,12 +552,12 @@ class QaicPlatform(Platform):
             if cache_config and cache_config.enable_prefix_caching:
                 if vllm_config.kv_transfer_config:
                     cache_config.block_size = vllm_config.additional_config.get(
-                        "kv_block_size"
-                    )
+                        "override_qaic_config", {}
+                    ).get("kv_block_size")
                 else:
                     cache_config.block_size = vllm_config.additional_config.get(
-                        "prefill_seq_len"
-                    )
+                        "override_qaic_config", {}
+                    ).get("prefill_seq_len")
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -306,7 +306,7 @@ class QaicPlatform(Platform):
                     )  # reset to "no-op" default
                     cache_config.mamba_cache_mode = "none"  # reset to disabled
                     cache_config.block_size = (
-                        scheduler_config.long_prefill_token_threshold
+                        vllm_config.additional_config.get("prefill_seq_len")
                     )
                 elif model_config.is_multimodal_model and model_config.is_encoder_decoder:
                     cache_config.block_size = 100000
@@ -550,7 +550,7 @@ class QaicPlatform(Platform):
             )
             cache_config = vllm_config.cache_config
             if cache_config and cache_config.enable_prefix_caching:
-                cache_config.block_size = scheduler_config.long_prefill_token_threshold
+                cache_config.block_size = vllm_config.additional_config.get("prefill_seq_len")
             if "override_qaic_config" not in vllm_config.additional_config:
                 additional_config["override_qaic_config"] = {}
             additional_config["override_qaic_config"].update(

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -1591,15 +1591,15 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     self.vllm_config,
                     self.device,
                 )
-        if self.model.paged_attention:
-            decode_block_table = np.arange(
-                self.model.decode_bsz * self.model.num_gpu_blocks_per_batch,
-                dtype=np.int64,
-            ).reshape(self.model.decode_bsz, self.model.num_gpu_blocks_per_batch)
-            decode_slot_ids = np.zeros(self.model.decode_bsz, dtype=np.int64)
-        else:
-            decode_block_table = None
-            decode_slot_ids = None
+        # if self.model.paged_attention:
+        #     decode_block_table = np.arange(
+        #         self.model.decode_bsz * self.model.num_gpu_blocks_per_batch,
+        #         dtype=np.int64,
+        #     ).reshape(self.model.decode_bsz, self.model.num_gpu_blocks_per_batch)
+        #     decode_slot_ids = np.zeros(self.model.decode_bsz, dtype=np.int64)
+        # else:
+        #     decode_block_table = None
+        #     decode_slot_ids = None
         self.kv_cache_info = (
             self.model.kv_cache_info if self.model.disagg_serving_en else None
         )

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -1591,15 +1591,6 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     self.vllm_config,
                     self.device,
                 )
-        # if self.model.paged_attention:
-        #     decode_block_table = np.arange(
-        #         self.model.decode_bsz * self.model.num_gpu_blocks_per_batch,
-        #         dtype=np.int64,
-        #     ).reshape(self.model.decode_bsz, self.model.num_gpu_blocks_per_batch)
-        #     decode_slot_ids = np.zeros(self.model.decode_bsz, dtype=np.int64)
-        # else:
-        #     decode_block_table = None
-        #     decode_slot_ids = None
         self.kv_cache_info = (
             self.model.kv_cache_info if self.model.disagg_serving_en else None
         )
@@ -1626,6 +1617,17 @@ class QaicModelRunnerAoT(GPUModelRunner):
             time_after_load - time_before_load,
         )
 
+    def _make_pa_warmup_arrays(
+        self, bsz: int
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        if not self.model.paged_attention:
+            return None, None
+        block_table = np.arange(
+            bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
+        ).reshape(bsz, self.model.num_gpu_blocks_per_batch)
+        slot_ids = np.zeros(bsz, dtype=np.int64)
+        return block_table, slot_ids
+
     def _qaic_dummy_run(self) -> None:
         if self.is_pooling_model:
             # TODO: check if pooler dummy run can be added
@@ -1647,14 +1649,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
         else:
             decode_positions = np.array([0] * decode_num_tokens, dtype=np.int64)
         decode_block_ids = np.arange(decode_bsz, dtype=np.int64)
-        if self.model.paged_attention:
-            decode_block_table = np.arange(
-                decode_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
-            ).reshape(decode_bsz, self.model.num_gpu_blocks_per_batch)
-            decode_slot_ids = np.zeros(decode_bsz, dtype=np.int64)
-        else:
-            decode_block_table = None
-            decode_slot_ids = None
+        decode_block_table, decode_slot_ids = self._make_pa_warmup_arrays(decode_bsz)
         decode_lora_ids = None
         if self.lora_config:
             decode_lora_ids = np.arange(decode_bsz, dtype=np.int64)
@@ -1694,14 +1689,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
         prefill_cum_sum = np.array(
             [prefill_seq_len] * prefill_bsz, dtype=np.int64
         ).cumsum()
-        if self.model.paged_attention:
-            prefill_block_table = np.arange(
-                prefill_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
-            ).reshape(prefill_bsz, self.model.num_gpu_blocks_per_batch)
-            prefill_slot_ids = np.zeros(prefill_bsz, dtype=np.int64)
-        else:
-            prefill_block_table = None
-            prefill_slot_ids = None
+        prefill_block_table, prefill_slot_ids = self._make_pa_warmup_arrays(prefill_bsz)
         prefill_lora_ids = None
         if self.lora_config:
             prefill_lora_ids = np.arange(prefill_bsz, dtype=np.int64)

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -815,6 +815,32 @@ class QaicModelRunnerAoT(GPUModelRunner):
             self.input_batch.block_table[0].get_numpy_array()[:num_reqs, 0] - 1
         )
 
+        if self.model.paged_attention:
+            # Compute block_table and slot_mapping from vLLM's block management
+            # block_table: (num_reqs, max_num_blocks_per_req)
+            self.block_table = (
+                self.input_batch.block_table[0].get_numpy_array()[:num_reqs].copy() - 1
+            )
+            block_size = self.cache_config.block_size
+            # Compute slot_mapping via compute_slot_mapping
+            # vLLM v0.23's expects (num_reqs, query_start_loc, positions) signature.
+            query_start_loc_np = np.concatenate(([0], cu_num_tokens[:num_reqs])).astype(
+                np.int32
+            )
+            self.input_batch.block_table.compute_slot_mapping(
+                num_reqs,
+                torch.from_numpy(query_start_loc_np),
+                torch.from_numpy(positions_np),
+            )
+            self.slot_mapping = (
+                self.input_batch.block_table[0]
+                .slot_mapping.np[:total_num_scheduled_tokens]
+                .copy()
+            )
+            # Compute per-request slot_id:
+            num_computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            self.slot_id = (num_computed % block_size).astype(np.int64)
+
         torch.add(
             self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
             torch.from_numpy(num_scheduled_tokens),
@@ -1153,6 +1179,11 @@ class QaicModelRunnerAoT(GPUModelRunner):
                 if not self.is_kv_consumer
                 else self.batch_indices[:num_scheduled_tokens]
             )
+            if self.model.paged_attention:
+                decode_block_table: np.ndarray = self.block_table[: self.num_decodes]
+                decode_slot_ids: np.ndarray = self.slot_id[: self.num_decodes]
+            else:
+                decode_block_table, decode_slot_ids = None, None
 
             if self.max_decode_tokens > 1:
                 # mark padded positions as -1 so QAIC hardware ignores them
@@ -1189,6 +1220,15 @@ class QaicModelRunnerAoT(GPUModelRunner):
             discard_request_mask_np = self.discard_request_mask.np[
                 : self.input_batch.num_reqs
             ].copy()
+            if self.model.paged_attention:
+                prefill_block_table: np.ndarray = self.block_table[
+                    self.num_decodes : self.input_batch.num_reqs
+                ]
+                prefill_slot_ids: np.ndarray = self.slot_id[
+                    self.num_decodes : self.input_batch.num_reqs
+                ]
+            else:
+                prefill_block_table, prefill_slot_ids = None, None
 
             # mm_kwargs_list is only needed for prefill requests; skip preprocessing
             # entirely when there are no prefills or the model has no mm inputs.
@@ -1251,6 +1291,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     logits=hidden_states_prefill,
                     kv_caches=self.kv_caches,
                     callback=callback,
+                    block_table=prefill_block_table,
+                    slot_id=prefill_slot_ids,
                     lora_ids=prefill_lora_ids,
                     num_prompt_tokens_prefill=num_prompt_tokens_prefill,
                 )
@@ -1266,6 +1308,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     is_prompt=False,
                     logits=hidden_states_decode,
                     callback=callback,
+                    block_table=decode_block_table,
+                    slot_id=decode_slot_ids,
                     lora_ids=decode_lora_ids,
                 )
 
@@ -1547,6 +1591,15 @@ class QaicModelRunnerAoT(GPUModelRunner):
                     self.vllm_config,
                     self.device,
                 )
+        if self.model.paged_attention:
+            decode_block_table = np.arange(
+                self.model.decode_bsz * self.model.num_gpu_blocks_per_batch,
+                dtype=np.int64,
+            ).reshape(self.model.decode_bsz, self.model.num_gpu_blocks_per_batch)
+            decode_slot_ids = np.zeros(self.model.decode_bsz, dtype=np.int64)
+        else:
+            decode_block_table = None
+            decode_slot_ids = None
         self.kv_cache_info = (
             self.model.kv_cache_info if self.model.disagg_serving_en else None
         )
@@ -1594,6 +1647,14 @@ class QaicModelRunnerAoT(GPUModelRunner):
         else:
             decode_positions = np.array([0] * decode_num_tokens, dtype=np.int64)
         decode_block_ids = np.arange(decode_bsz, dtype=np.int64)
+        if self.model.paged_attention:
+            decode_block_table = np.arange(
+                decode_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
+            ).reshape(decode_bsz, self.model.num_gpu_blocks_per_batch)
+            decode_slot_ids = np.zeros(decode_bsz, dtype=np.int64)
+        else:
+            decode_block_table = None
+            decode_slot_ids = None
         decode_lora_ids = None
         if self.lora_config:
             decode_lora_ids = np.arange(decode_bsz, dtype=np.int64)
@@ -1613,6 +1674,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
             is_prompt=False,
             logits=decode_logits,
             mm_kwargs_list=decode_mm_kwargs_list,
+            block_table=decode_block_table,
+            slot_id=decode_slot_ids,
         )
 
         # Prefill
@@ -1631,6 +1694,14 @@ class QaicModelRunnerAoT(GPUModelRunner):
         prefill_cum_sum = np.array(
             [prefill_seq_len] * prefill_bsz, dtype=np.int64
         ).cumsum()
+        if self.model.paged_attention:
+            prefill_block_table = np.arange(
+                prefill_bsz * self.model.num_gpu_blocks_per_batch, dtype=np.int64
+            ).reshape(prefill_bsz, self.model.num_gpu_blocks_per_batch)
+            prefill_slot_ids = np.zeros(prefill_bsz, dtype=np.int64)
+        else:
+            prefill_block_table = None
+            prefill_slot_ids = None
         prefill_lora_ids = None
         if self.lora_config:
             prefill_lora_ids = np.arange(prefill_bsz, dtype=np.int64)
@@ -1648,6 +1719,8 @@ class QaicModelRunnerAoT(GPUModelRunner):
             prefill_cum_sum=prefill_cum_sum,
             mm_kwargs_list=mm_kwargs_list,
             logits=prefill_logits,
+            block_table=prefill_block_table,
+            slot_id=prefill_slot_ids,
         )
 
         if self.use_async_scheduling:

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -636,13 +636,40 @@ class QaicWorkerAoT(QaicWorker):
         self.cache_config.sliding_window = None
 
         assert num_cpu_blocks == 0
+        if self.model_config.enforce_eager:
+            # adapted from gpu_worker.py
+            self.cache_config.num_gpu_blocks = num_gpu_blocks
+            return
+
         if not self.cache_config.enable_prefix_caching:
             self.cache_config.num_gpu_blocks = num_gpu_blocks
             # Sanity check: AOT requires exact block count; eager is flexible
-            assert num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
+            assert (
+                self.model_config.enforce_eager
+                or num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
+            )
             return
-        else:
-            raise NotImplementedError("prefix caching is not supported on QAIC in V1")
+        elif (
+            not self.model_config.enforce_eager
+            and self.cache_config.enable_prefix_caching
+        ):
+            if self.cache_config.num_gpu_blocks_override:
+                self.cache_config.num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * self.cache_config.num_gpu_blocks_override
+                    + 1
+                )
+            else:
+                # For prefix caching, we need to calculate the number of GPU blocks
+                # based on the max model length and block size.
+                self.cache_config.num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * (
+                        self.model_config.max_model_len
+                        // self.scheduler_config.long_prefill_token_threshold
+                    )
+                    + 1
+                )
 
     def init_device(self):
         """Initialize qaic device
@@ -702,11 +729,24 @@ class QaicWorkerAoT(QaicWorker):
         pass
 
     def determine_available_memory(self) -> int:
-        num_gpu_blocks = (
-            self.cache_config.num_gpu_blocks_override
-            if self.cache_config.num_gpu_blocks_override
-            else self.scheduler_config.max_num_seqs
-        ) + 1
+        if self.vllm_config.cache_config.enable_prefix_caching:
+            if self.cache_config.num_gpu_blocks_override:
+                num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * self.cache_config.num_gpu_blocks_override
+                    + 1
+                )
+            else:
+                num_gpu_blocks = (
+                    self.scheduler_config.max_num_seqs
+                    * (
+                        self.vllm_config.model_config.max_model_len
+                        // self.scheduler_config.long_prefill_token_threshold
+                    )
+                    + 1
+                )
+        else:
+            num_gpu_blocks = self.scheduler_config.max_num_seqs + 1
         # adapted from get_uniform_page_size
         page_sizes = set(
             layer.page_size_bytes for layer in self.get_kv_cache_spec().values()

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -666,7 +666,7 @@ class QaicWorkerAoT(QaicWorker):
                     self.scheduler_config.max_num_seqs
                     * (
                         self.model_config.max_model_len
-                        // self.scheduler_config.long_prefill_token_threshold
+                        // self.cache_config.block_size
                     )
                     + 1
                 )
@@ -741,7 +741,7 @@ class QaicWorkerAoT(QaicWorker):
                     self.scheduler_config.max_num_seqs
                     * (
                         self.vllm_config.model_config.max_model_len
-                        // self.scheduler_config.long_prefill_token_threshold
+                        // self.cache_config.block_size
                     )
                     + 1
                 )

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -664,10 +664,7 @@ class QaicWorkerAoT(QaicWorker):
                 # based on the max model length and block size.
                 self.cache_config.num_gpu_blocks = (
                     self.scheduler_config.max_num_seqs
-                    * (
-                        self.model_config.max_model_len
-                        // self.cache_config.block_size
-                    )
+                    * (self.model_config.max_model_len // self.cache_config.block_size)
                     + 1
                 )
 

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -40,6 +40,7 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
 from vllm.utils.torch_utils import set_random_seed
+from vllm.utils.math_utils import cdiv
 from vllm.v1.core.sched.output import GrammarOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
@@ -632,9 +633,8 @@ class QaicWorkerPyt(QaicWorker):
 class QaicWorkerAoT(QaicWorker):
     def _compute_num_gpu_blocks(self) -> int:
         if self.cache_config.enable_prefix_caching:
-            blocks_per_seq = (
-                self.cache_config.num_gpu_blocks_override
-                or self.model_config.max_model_len // self.cache_config.block_size
+            blocks_per_seq = self.cache_config.num_gpu_blocks_override or cdiv(
+                self.model_config.max_model_len, self.cache_config.block_size
             )
             return self.scheduler_config.max_num_seqs * blocks_per_seq + 1
         return self.scheduler_config.max_num_seqs + 1

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -630,6 +630,15 @@ class QaicWorkerPyt(QaicWorker):
 
 
 class QaicWorkerAoT(QaicWorker):
+    def _compute_num_gpu_blocks(self) -> int:
+        if self.cache_config.enable_prefix_caching:
+            blocks_per_seq = (
+                self.cache_config.num_gpu_blocks_override
+                or self.model_config.max_model_len // self.cache_config.block_size
+            )
+            return self.scheduler_config.max_num_seqs * blocks_per_seq + 1
+        return self.scheduler_config.max_num_seqs + 1
+
     def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:
         self.cache_config.num_cpu_blocks = num_cpu_blocks
         # disable sliding window
@@ -643,30 +652,10 @@ class QaicWorkerAoT(QaicWorker):
 
         if not self.cache_config.enable_prefix_caching:
             self.cache_config.num_gpu_blocks = num_gpu_blocks
-            # Sanity check: AOT requires exact block count; eager is flexible
-            assert (
-                self.model_config.enforce_eager
-                or num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
-            )
+            assert num_gpu_blocks == self.scheduler_config.max_num_seqs + 1
             return
-        elif (
-            not self.model_config.enforce_eager
-            and self.cache_config.enable_prefix_caching
-        ):
-            if self.cache_config.num_gpu_blocks_override:
-                self.cache_config.num_gpu_blocks = (
-                    self.scheduler_config.max_num_seqs
-                    * self.cache_config.num_gpu_blocks_override
-                    + 1
-                )
-            else:
-                # For prefix caching, we need to calculate the number of GPU blocks
-                # based on the max model length and block size.
-                self.cache_config.num_gpu_blocks = (
-                    self.scheduler_config.max_num_seqs
-                    * (self.model_config.max_model_len // self.cache_config.block_size)
-                    + 1
-                )
+        else:
+            self.cache_config.num_gpu_blocks = self._compute_num_gpu_blocks()
 
     def init_device(self):
         """Initialize qaic device
@@ -726,24 +715,7 @@ class QaicWorkerAoT(QaicWorker):
         pass
 
     def determine_available_memory(self) -> int:
-        if self.vllm_config.cache_config.enable_prefix_caching:
-            if self.cache_config.num_gpu_blocks_override:
-                num_gpu_blocks = (
-                    self.scheduler_config.max_num_seqs
-                    * self.cache_config.num_gpu_blocks_override
-                    + 1
-                )
-            else:
-                num_gpu_blocks = (
-                    self.scheduler_config.max_num_seqs
-                    * (
-                        self.vllm_config.model_config.max_model_len
-                        // self.cache_config.block_size
-                    )
-                    + 1
-                )
-        else:
-            num_gpu_blocks = self.scheduler_config.max_num_seqs + 1
+        num_gpu_blocks = self._compute_num_gpu_blocks()
         # adapted from get_uniform_page_size
         page_sizes = set(
             layer.page_size_bytes for layer in self.get_kv_cache_spec().values()


### PR DESCRIPTION
**Summary**

This PR adds paged (block-based) KV cache support to the QAIC AOT execution path, which enables prefix caching on vLLM v1. Without paged-attention AOT allocated one contiguous KV region per sequence, sized to the full context length. That meant:

Prefix caching was explicitly unsupported and raised NotImplementedError.
Shared prompt prefixes were recomputed on every request.

With paged attention, KV cache is carved into fixed-size blocks managed by vLLM's block manager and addressed on-device through a per-request block table. Requests only occupy the blocks they need, and identical prefixes can be reused across requests.

**Configuration**
Paged Attention can be enabled by setting --enable-prefix-caching=True.
Block count is derived automatically from the model's context length and prefill chunk size,

**Limitations**
Currently, KV block size is tied to prefill-seq-len; it is not independently configurable.