### PR TITLE
Paged attention unit tests

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -135,11 +135,20 @@ def _parse_device_id_pool(value: str) -> list[int]:
 
 
 def pytest_addoption(parser):
+    parser.addoption(
+        "--model-name",
+        action="store",
+        dest="model_name",
+        default=None,
+        help="Model name",
+    )
     parser.addoption("--seq-len", type=int, default=None)
     parser.addoption("--ctx-len", type=int, default=None)
     parser.addoption("--decode-bsz", type=int, default=4)
     parser.addoption("--dtype", type=str, default=None)
     parser.addoption("--kv-dtype", type=str, default="auto")
+    parser.addoption("--quantization", type=str, default=None, dest="quantization")
+    parser.addoption("--max-end-tokens", type=int, default=None, dest="max_end_tokens")
     parser.addoption("--dataset", type=str, default=None)
     parser.addoption(
         "--device-id",
@@ -160,6 +169,20 @@ def pytest_addoption(parser):
     )
     parser.addoption("--host", type=str, default="127.0.0.1")
     parser.addoption("--port", type=int, default=None)
+    parser.addoption(
+        "--device-group",
+        type=int,
+        default=None,
+        dest="device_group_size",
+        help="Number of devices per device group",
+    )
+    parser.addoption(
+        "--prefix-cache",
+        type=lambda v: v.lower() != "false",
+        default=None,
+        dest="enable_prefix_caching",
+        help="Enable prefix caching (True/False)",
+    )
     parser.addoption(
         "--override-qaic-config",
         type=_parse_override_config,
@@ -367,17 +390,21 @@ def make_runner(
         async_scheduling: bool,
         dg: list,
         enable_chunked_prefill: bool = False,
+        enable_prefix_caching: bool = False,
         block_size: int = 16,
         lora_modules: list | None = None,
         max_num_seqs: int | None = None,
         override_qaic_config: dict | None = override_qaic_config,
         quantization: str | None = dtype,
         kv_cache_dtype: str = kv_dtype,
-        long_prefill_token_threshold: int | None = None,
         **kwargs,
     ):
+        qaic_cfg = (
+            dict(override_qaic_config) if override_qaic_config is not None else {}
+        )
+        qaic_cfg["prefill_seq_len"] = seq_len
         additional_config = {
-            "override_qaic_config": override_qaic_config,
+            "override_qaic_config": qaic_cfg,
             "device_group": dg,
         }
         if lora_modules is not None:
@@ -386,15 +413,10 @@ def make_runner(
             model_name,
             max_num_seqs=max_num_seqs if max_num_seqs is not None else decode_bsz,
             max_model_len=ctx_len,
-            long_prefill_token_threshold=(
-                seq_len
-                if long_prefill_token_threshold is None
-                else long_prefill_token_threshold
-            ),
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
             additional_config=additional_config,
-            enable_prefix_caching=False,
+            enable_prefix_caching=enable_prefix_caching,
             async_scheduling=async_scheduling,
             disable_log_stats=False,
             enable_chunked_prefill=enable_chunked_prefill,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -519,12 +519,19 @@ def qaic_model(
     device_group_size = _resolve_qaic_test_config_value(
         request, pytestconfig, "device_group_size", default=1
     )
+    enable_prefix_caching = _resolve_qaic_test_config_value(
+        request, pytestconfig, "enable_prefix_caching", default=False
+    )
 
     ids = _device_pool.acquire(device_pool_ids, num_device_groups * device_group_size)
     try:
+        qaic_cfg = (
+            dict(override_qaic_config) if override_qaic_config is not None else {}
+        )
+        qaic_cfg["prefill_seq_len"] = seq_len
         additional_config = {
             "device_group": ids,
-            "override_qaic_config": override_qaic_config,
+            "override_qaic_config": qaic_cfg,
         }
         if draft_override_qaic_config is not None:
             additional_config["draft_override_qaic_config"] = draft_override_qaic_config
@@ -537,10 +544,9 @@ def qaic_model(
             model_name,
             max_num_seqs=decode_bsz,
             max_model_len=ctx_len,
-            long_prefill_token_threshold=seq_len,
             quantization=dtype,
             kv_cache_dtype=kv_dtype,
-            enable_prefix_caching=False,
+            enable_prefix_caching=enable_prefix_caching,
             async_scheduling=False,
             speculative_config=speculative_config,
             enable_lora=enable_lora,
@@ -566,9 +572,23 @@ def pytest_collection_modifyitems(session, config, items):
         if device_pool_size is not None
         else len(config.getoption("device_id"))
     )
+    cli_prefix_cache = config.getoption("enable_prefix_caching", default=None)
     for item in items:
         marker = item.get_closest_marker("qaic_test_config")
         kwargs = marker.kwargs if marker is not None else {}
+        if (
+            cli_prefix_cache is not None
+            and "enable_prefix_caching" in kwargs
+            and kwargs["enable_prefix_caching"] != cli_prefix_cache
+        ):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=(
+                        f"--prefix-cache={cli_prefix_cache} set; skipping "
+                        f"enable_prefix_caching={kwargs['enable_prefix_caching']} test"
+                    )
+                )
+            )
         num_device_groups = kwargs.get("num_device_groups", 1)
         device_group_size = kwargs.get("device_group_size", 1)
         required = num_device_groups * device_group_size

--- a/tests/e2e/multimodal/test_multimodal.py
+++ b/tests/e2e/multimodal/test_multimodal.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # ------------------------------------------------------------------
 import random
+from difflib import SequenceMatcher
 
 import pytest
 import regex as re
@@ -473,6 +474,88 @@ def _qwenvl_multi_resolution_test(
         print(o1.outputs[0].text)
         print(o2.outputs[0].text)
         assert o1.outputs[0].text == o2.outputs[0].text
+
+
+@pytest.mark.qaic_test_config(
+    model_name="Qwen/Qwen2.5-VL-3B-Instruct",
+    ctx_len=4096,
+    dtype="mxfp6",
+    kv_dtype="mxint8",
+    num_device_groups=2,
+    device_group_size=1,
+)
+def test_paged_attention_single_image(
+    mm_input, model_name, device_groups, make_runner, ctx_len, seq_len
+):
+    """Compare single-batch (no prefix-caching) outputs against
+    paged-attention (prefix_caching=True) outputs."""
+    tokenizer = _tokenizer_for(model_name)
+    sampling_params = _sampling_params_for(model_name, tokenizer)
+    updated_input = build_model_input(model_name, mm_input, tokenizer)
+    override_cfg = update_qaic_config(model_name, None)
+    mm_kwargs = _mm_processor_kwargs(model_name)
+
+    inputs = [
+        {"prompt": p, "multi_modal_data": {"image": img}} for img, p in updated_input
+    ]
+    repeated_inputs = inputs * 3
+    random.shuffle(repeated_inputs)
+
+    with make_runner(
+        async_scheduling=False,
+        dg=device_groups[0],
+        max_num_seqs=1,
+        runner="pooling",
+        quantization=None,
+        kv_cache_dtype="auto",
+        override_qaic_config=override_cfg,
+        trust_remote_code=is_internvl(model_name),
+        enable_mm_embeds=True,
+        limit_mm_per_prompt={"image": 1},
+        **mm_kwargs,
+    ) as qllm_embed:
+        gen_inputs = encode_if_mm(qllm_embed, repeated_inputs, model_name)
+
+    with make_runner(
+        async_scheduling=False,
+        dg=device_groups[1],
+        max_num_seqs=1,
+        override_qaic_config=override_cfg,
+        trust_remote_code=is_internvl(model_name),
+        enable_mm_embeds=True,
+        limit_mm_per_prompt={"image": 1},
+        enable_prefix_caching=False,
+        **mm_kwargs,
+    ) as qllm_gen:
+        outputs = qllm_gen.llm.generate(gen_inputs, sampling_params=sampling_params)
+
+    with make_runner(
+        async_scheduling=False,
+        dg=device_groups[1],
+        max_num_seqs=1,
+        override_qaic_config=override_cfg,
+        trust_remote_code=is_internvl(model_name),
+        enable_mm_embeds=True,
+        limit_mm_per_prompt={"image": 1},
+        enable_prefix_caching=True,
+        **mm_kwargs,
+    ) as qllm_gen_pa:
+        outputs_pa = qllm_gen_pa.llm.generate(
+            gen_inputs, sampling_params=sampling_params
+        )
+
+    assert len(outputs) == len(outputs_pa) == len(repeated_inputs)
+    for o1, o2 in zip(outputs, outputs_pa, strict=False):
+        assert len(o2.outputs[0].text) > 1
+        print(o1.outputs[0].text)
+        print(o2.outputs[0].text)
+        ids1 = o1.outputs[0].token_ids
+        ids2 = o2.outputs[0].token_ids
+        similarity = SequenceMatcher(None, ids1, ids2).ratio()
+        assert similarity >= 0.5, (
+            f"Output similarity {similarity:.3f} below threshold.\n"
+            f"no-pa: {o1.outputs[0].text!r}\npa:    {o2.outputs[0].text!r}"
+        )
 
 
 @pytest.mark.qaic_test_config(

--- a/tests/e2e/paged_attention/__init__.py
+++ b/tests/e2e/paged_attention/__init__.py
@@ -1,0 +1,4 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------

--- a/tests/e2e/paged_attention/run_paged_attention.sh
+++ b/tests/e2e/paged_attention/run_paged_attention.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+set -e
+
+echo "-------------------Paged Attention Test Suite-------------------"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="${SCRIPT_DIR}"
+
+declare -i device_id=0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Test PA with different prompt lengths: a) prompt_len < block_size
+#    b) prompt_len = block_size  c) prompt_len > block_size
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Validate Paged Attention outputs with different prompt lengths"
+pytest --disable-warnings -s -v "${TEST_DIR}/test_paged_attention.py::test_with_different_prompt_lengths" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --decode-bsz 4 \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Test with different dbsz, num_kv_blocks and ctx_len - also validates batch invariance
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Validate Paged Attention outputs with different configurations"
+pytest --disable-warnings -s -v "${TEST_DIR}/test_paged_attention.py::test_pa_model_outputs" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Prefix caching multichat test
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Prefix Caching Test"
+pytest --disable-warnings -s -v "${TEST_DIR}/../test_multichat.py" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --seq-len 32 \
+    --ctx-len 1024 \
+    --decode-bsz 16 \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8" \
+    --device-id "${device_id}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Performance gains on prefix caching: work with 8K CL
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Paged Attention Performance Test"
+pytest --disable-warnings -s -v "${TEST_DIR}/test_paged_attention.py::test_prefix_caching_performance" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --seq-len 128 \
+    --ctx-len 8192 \
+    --decode-bsz 4 \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8" \
+    --device-id "${device_id}, ${device_id+1}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. T9 accuracy test for paged attention (T9 support for PA)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Model Accuracy Test with Prefix Caching"
+pytest --disable-warnings -s -v "${TEST_DIR}/../test_accuracy.py" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --seq-len 128 \
+    --ctx-len 2048 \
+    --decode-bsz 4 \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8" \
+    --device-group 1 \
+    --device-id "${device_id}" \
+    --prefix-cache "True"
+
+echo "Model Accuracy Test without Prefix Caching"
+pytest --disable-warnings -s -v "${TEST_DIR}/../test_accuracy.py" \
+    --model-name "meta-llama/Llama-3.1-8B-Instruct" \
+    --seq-len 128 \
+    --ctx-len 2048 \
+    --decode-bsz 4 \
+    --dtype "mxfp6" \
+    --kv-dtype "mxint8" \
+    --device-group 1 \
+    --device-id "${device_id}" \
+    --prefix-cache "False"
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. MultiModal Test With Paged Attention
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Paged Attention: MultiModal (Qwen2.5-VL) ==="
+pytest --disable-warnings -s -v "${TEST_DIR}/../multimodal/test_multimodal.py::test_paged_attention_single_image" \
+    --model-name "Qwen/Qwen2.5-VL-3B-Instruct" \
+    --seq-len 128 \
+    --ctx-len 4096 \
+    --decode-bsz 1 \
+    --dtype "auto" \
+    --quantization "mxfp6" \
+    --kv-dtype "mxint8" \
+    --device-group 1 \
+    --device-id "${device_id},${device_id+1}" \
+    --max-end-tokens 40

--- a/tests/e2e/paged_attention/test_paged_attention.py
+++ b/tests/e2e/paged_attention/test_paged_attention.py
@@ -1,0 +1,271 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+
+from pathlib import Path
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm import LLM, SamplingParams
+
+from ...conftest import VllmRunner
+
+
+def _resolve(request, pytestconfig, key, default=None):
+    """Resolve a QAIC run-config value: closest `qaic_test_config` marker
+    kwarg first, then the matching CLI option, then `default`."""
+    marker = request.node.get_closest_marker("qaic_test_config")
+    if marker is not None and key in marker.kwargs:
+        return marker.kwargs[key]
+    cli_value = pytestconfig.getoption(key, default=None)
+    if cli_value is not None:
+        return cli_value
+    return default
+
+
+@pytest.fixture
+def qaic_test_config(request, pytestconfig):
+    """Per-test QAIC run configuration, resolved from the `qaic_test_config`
+    marker kwargs first, then matching CLI options, then defaults."""
+    defaults = {
+        "model_name": "meta-llama/Llama-3.1-8B-Instruct",
+        "seq_len": 32,
+        "ctx_len": 256,
+        "decode_bsz": 4,
+        "dtype": "mxfp6",
+        "kv_dtype": "mxint8",
+        "override_qaic_config": None,
+    }
+    return {
+        key: _resolve(request, pytestconfig, key, default=default)
+        for key, default in defaults.items()
+    }
+
+
+@pytest.fixture
+def make_runner(qaic_test_config):
+    def _make(
+        dg: list,
+        ctx_len: int | None = None,
+        seq_len: int | None = None,
+        decode_bsz: int | None = None,
+        async_scheduling: bool = False,
+        enable_chunked_prefill: bool = False,
+        prefix_caching: bool = False,
+        **kwargs,
+    ) -> VllmRunner:
+        _seq_len = seq_len if seq_len is not None else qaic_test_config["seq_len"]
+        _override = dict(qaic_test_config["override_qaic_config"] or {})
+        _override["prefill_seq_len"] = _seq_len
+        return VllmRunner(
+            qaic_test_config["model_name"],
+            max_num_seqs=decode_bsz
+            if decode_bsz is not None
+            else qaic_test_config["decode_bsz"],
+            max_model_len=ctx_len
+            if ctx_len is not None
+            else qaic_test_config["ctx_len"],
+            quantization=qaic_test_config["dtype"],
+            kv_cache_dtype=qaic_test_config["kv_dtype"],
+            additional_config={
+                "override_qaic_config": _override,
+                "device_group": dg,
+            },
+            enable_prefix_caching=prefix_caching,
+            async_scheduling=async_scheduling,
+            disable_log_stats=False,
+            enable_chunked_prefill=enable_chunked_prefill,
+            **kwargs,
+        )
+
+    return _make
+
+
+def _extract_metrics(req_outputs):
+    """Extract per-request KPIs from RequestOutput.metrics (RequestStateStats)."""
+    ttfts, decode_times, e2e_latencies, output_tokens = [], [], [], []
+    for req in req_outputs:
+        m = req.metrics
+        if m is None:
+            continue
+        ttfts.append(m.first_token_ts - m.scheduled_ts)
+        if m.first_token_ts > 0 and m.last_token_ts > 0:
+            decode_times.append(m.last_token_ts - m.first_token_ts)
+            e2e_latencies.append(m.last_token_ts - m.scheduled_ts)
+        output_tokens.append(m.num_generation_tokens)
+    return ttfts, decode_times, e2e_latencies, output_tokens
+
+
+# T1: Validate PA model with different prompt lengths
+def test_with_different_prompt_lengths(make_runner, device_group, qaic_test_config):
+    """
+    Validate how block_table and slot_id updates happen for the following
+    three scenarios: a) prompt_len < block_size b) prompt_len = block_size
+    c) prompt_len > block_size. We have three prompts such that P1 < 32
+    tokens, P2 = 32 tokens and P3 > 32 tokens and we test with a
+    seq_len = block_size = 32.
+    """
+    base = (
+        "My name is John Smith and I am a software engineer. "
+        "I have been working in the industry for the past 5 years "
+        "and have been fortunate"
+    )
+    prompts = [
+        base,
+        base + " enough to",
+        base + " enough to work on some",
+    ]
+    sampling_params = SamplingParams(temperature=0)
+    with make_runner(
+        dg=device_group,
+        ctx_len=256,
+        seq_len=32,
+        enable_chunked_prefill=True,
+        prefix_caching=True,
+    ) as runner:
+        outputs = runner.llm.generate(prompts, sampling_params=sampling_params)
+
+    final_outputs = [output.prompt + output.outputs[0].text for output in outputs]
+    tokenizer = AutoTokenizer.from_pretrained(qaic_test_config["model_name"])
+    min_tokens_to_check = len(
+        tokenizer.encode(final_outputs[0], add_special_tokens=False)
+    )
+    for output in final_outputs:
+        assert output[:min_tokens_to_check] == final_outputs[0][:min_tokens_to_check], (
+            "Outputs do not match for different prompt lengths!!"
+        )
+
+
+# T2: Validate PA model outputs across various batch sizes, num_kv_blocks,
+# and ctx_lengths - this also validates batch invariance
+def test_pa_model_outputs(make_runner, device_group):
+    prompts = ["My name is"] * 16
+    batch_sizes = [1, 4, 16]
+    ctx_lengths = [512, 1024, 2048]
+    seq_lens = [32, 128]
+    sampling_params = SamplingParams(temperature=0)
+
+    results = []
+    for decode_bsz in batch_sizes:
+        for ctx_len in ctx_lengths:
+            for seq_len in seq_lens:
+                with make_runner(
+                    dg=device_group,
+                    decode_bsz=decode_bsz,
+                    ctx_len=ctx_len,
+                    seq_len=seq_len,
+                    enable_chunked_prefill=True,
+                    prefix_caching=True,
+                ) as runner:
+                    outputs = runner.llm.generate(
+                        prompts, sampling_params=sampling_params
+                    )
+                for output in outputs:
+                    results.append(
+                        {"prompt": output.prompt, "output": output.outputs[0].text}
+                    )
+
+    base_prompt, base_text = results[0]["prompt"], results[0]["output"]
+    for res in results:
+        assert res["prompt"] == base_prompt, "Prompts are not matching"
+        assert res["output"] == base_text, "Generated text is not same"
+
+
+# T3: Performance gains on prefix caching
+@pytest.mark.qaic_test_config(num_device_groups=2, device_group_size=1)
+def test_prefix_caching_performance(make_runner, device_groups, qaic_test_config):
+    sampling_params = SamplingParams(temperature=0)
+    sys_prompt = (Path(__file__).resolve().parents[4] / "15k_prompt.txt").read_text()
+    tokenizer = AutoTokenizer.from_pretrained(qaic_test_config["model_name"])
+    sys_tokens = tokenizer.encode(sys_prompt, add_special_tokens=False)
+    sys_prompt = tokenizer.decode(sys_tokens[:8000])
+    sub_prompt_1 = tokenizer.decode(sys_tokens[:2500])
+    sub_prompt_2 = tokenizer.decode(sys_tokens[:5000])
+    sub_prompt_3 = tokenizer.decode(sys_tokens[:7500])
+    warmup_prompts = [sys_prompt] * qaic_test_config["decode_bsz"]
+    prompts = [sys_prompt, sub_prompt_1, sub_prompt_2, sub_prompt_3]
+
+    with make_runner(
+        dg=device_groups[0], enable_chunked_prefill=True, prefix_caching=True
+    ) as runner:
+        # Warmup run to cache the KV blocks.
+        runner.llm.generate(warmup_prompts, sampling_params=sampling_params)
+        outputs_1 = runner.llm.generate(prompts, sampling_params=sampling_params)
+
+    with make_runner(
+        dg=device_groups[1], enable_chunked_prefill=True, prefix_caching=False
+    ) as runner:
+        outputs_2 = runner.llm.generate(prompts, sampling_params=sampling_params)
+
+    ttfts_1, _, _, _ = _extract_metrics(outputs_1)
+    ttfts_2, _, _, _ = _extract_metrics(outputs_2)
+    avg_ttft_1 = abs(sum(ttfts_1) / len(ttfts_1))
+    avg_ttft_2 = abs(sum(ttfts_2) / len(ttfts_2))
+    print(
+        f"Avg TTFT with prefix_cache: {avg_ttft_1:.3f}s | "
+        f"Avg TTFT without prefix_cache: {avg_ttft_2:.3f}s"
+    )
+    print(f"Prefix Caching Speedup : {avg_ttft_2 / avg_ttft_1:.3f}x")
+    assert avg_ttft_1 < avg_ttft_2, "No prefix caching benefit observed in TTFT"
+
+
+@pytest.mark.qaic_test_config(num_device_groups=2, device_group_size=1)
+def test_paged_attention_spd(device_groups, qaic_test_config):
+    baseline_device_group, test_device_group = device_groups
+    model_name = qaic_test_config["model_name"]
+    ctx_len = qaic_test_config["ctx_len"]
+    seq_len = qaic_test_config["seq_len"]
+    decode_bsz = qaic_test_config["decode_bsz"]
+
+    qllm_base = LLM(
+        model=model_name,
+        max_num_seqs=decode_bsz,
+        max_model_len=ctx_len,
+        long_prefill_token_threshold=seq_len,
+        quantization="mxfp6",
+        kv_cache_dtype="mxint8",
+        async_scheduling=False,
+        disable_log_stats=False,
+        enable_prefix_caching=True,
+        gpu_memory_utilization=1.0,
+        additional_config={"device_group": baseline_device_group},
+    )
+    qllm_spd = LLM(
+        model=model_name,
+        max_num_seqs=decode_bsz,
+        max_model_len=ctx_len,
+        long_prefill_token_threshold=seq_len,
+        quantization="mxfp6",
+        kv_cache_dtype="mxint8",
+        disable_log_stats=False,
+        async_scheduling=False,
+        enable_prefix_caching=True,
+        gpu_memory_utilization=1.0,
+        speculative_config={
+            "method": "draft_model",
+            "num_speculative_tokens": 5,
+            "model": "meta-llama/Llama-3.2-1B-Instruct",
+            "quantization": "mxfp6",
+        },
+        additional_config={
+            "device_group": baseline_device_group,
+            "draft_override_qaic_config": {"device_group": test_device_group},
+        },
+    )
+
+    sampling_params = SamplingParams(temperature=0)
+    prompts = [
+        "The history of artificial intelligence dates back",
+        "Speculative decoding accelerates inference by",
+        "Large language models are trained on",
+        "The key difference between supervised and unsupervised learning is",
+    ] * 5
+    outputs_base = qllm_base.generate(prompts, sampling_params)
+    outputs_spd = qllm_spd.generate(prompts, sampling_params)
+
+    for op_base, op_spd in zip(outputs_base, outputs_spd, strict=False):
+        assert op_base.prompt == op_spd.prompt
+        assert op_base.outputs[0].text == op_spd.outputs[0].text
+        assert op_base.outputs[0].token_ids == op_spd.outputs[0].token_ids

--- a/tests/e2e/test_accuracy.py
+++ b/tests/e2e/test_accuracy.py
@@ -210,12 +210,6 @@ def log_perf_metrics(id, metrics, device_group):
 
 
 class _AccuracyTestBase:
-    @pytest.mark.qaic_test_config(
-        model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        ctx_len=256,
-        dtype="mxfp6",
-        kv_dtype="mxint8",
-    )
     def test_accuracy(
         self,
         qaic_model,

--- a/tests/e2e/test_accuracy.py
+++ b/tests/e2e/test_accuracy.py
@@ -209,7 +209,7 @@ def log_perf_metrics(id, metrics, device_group):
     return rouge_1, rouge_2, rouge_L
 
 
-class TestAccuracy:
+class _AccuracyTestBase:
     @pytest.mark.qaic_test_config(
         model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
         ctx_len=256,
@@ -247,3 +247,13 @@ class TestAccuracy:
         assert r1 is not None, "[ERROR] Rouge1 score is None"
         assert r2 is not None, "[ERROR] Rouge2 score is None"
         assert rL is not None, "[ERROR] RougeL score is None"
+
+
+@pytest.mark.qaic_test_config(enable_prefix_caching=True)
+class TestAccuracyPrefixCaching(_AccuracyTestBase):
+    pass
+
+
+@pytest.mark.qaic_test_config(enable_prefix_caching=False)
+class TestAccuracy(_AccuracyTestBase):
+    pass

--- a/tests/e2e/test_multichat.py
+++ b/tests/e2e/test_multichat.py
@@ -1,0 +1,83 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+
+import pytest
+
+from vllm import SamplingParams
+
+ITERATIONS = 6
+MAX_END_TOKENS = 20
+KV_CACHE_SZ = 160
+
+
+def _run_multichat(
+    make_runner,
+    dg,
+    sharegpt_prompts,
+    decode_bsz,
+    prefix_caching,
+):
+    sampling_params = SamplingParams(temperature=0, max_tokens=MAX_END_TOKENS)
+
+    with make_runner(
+        async_scheduling=False,
+        dg=dg,
+        enable_prefix_caching=prefix_caching,
+        num_gpu_blocks_override=KV_CACHE_SZ if prefix_caching else None,
+    ) as runner:
+        prompts = None
+        avg_ttfts = []
+        for _ in range(ITERATIONS):
+            new_turns = sharegpt_prompts(decode_bsz)
+            prompts = (
+                new_turns
+                if prompts is None
+                else [p + " " + t for p, t in zip(prompts, new_turns, strict=False)]
+            )
+
+            outputs = runner.llm.generate(prompts, sampling_params)
+            iter_ttfts = [
+                op.metrics.first_token_ts - op.metrics.scheduled_ts for op in outputs
+            ]
+            avg_ttfts.append(sum(iter_ttfts) / len(iter_ttfts))
+
+            prompts = [
+                p + op.outputs[0].text for p, op in zip(prompts, outputs, strict=False)
+            ]
+
+    return sum(avg_ttfts) / len(avg_ttfts)
+
+
+@pytest.mark.qaic_test_config(
+    model_name="meta-llama/Llama-3.1-8B-Instruct",
+    seq_len=32,
+    ctx_len=1024,
+    decode_bsz=16,
+    dtype="mxfp6",
+    kv_dtype="mxint8",
+)
+def test_multichat_correctness(
+    make_runner, device_group, decode_bsz, seq_len, ctx_len, sharegpt_prompts
+):
+    """Multi-turn chat (each turn appends a new user message to the
+    conversation so far) run with and without prefix caching. Prefix
+    caching must not increase average TTFT."""
+    assert decode_bsz <= KV_CACHE_SZ, "kv cache size should >= decode_bsz"
+    assert (seq_len + MAX_END_TOKENS) * ITERATIONS <= ctx_len
+
+    avg_ttft_with_caching = _run_multichat(
+        make_runner, device_group, sharegpt_prompts, decode_bsz, prefix_caching=True
+    )
+    avg_ttft_without_caching = _run_multichat(
+        make_runner, device_group, sharegpt_prompts, decode_bsz, prefix_caching=False
+    )
+
+    print(
+        f"Prefix Caching E2E speed-up: "
+        f"{avg_ttft_without_caching / avg_ttft_with_caching:.3f}x"
+    )
+    assert avg_ttft_with_caching <= avg_ttft_without_caching, (
+        "No prefix caching benefit observed in TTFT"
+    )


### PR DESCRIPTION
Adds an automated test suite for Paged Attention that validates:

Test Coverage
1. Correctness across varying prompt lengths and KV block boundaries
2. Output consistency across different runtime configurations
3. Batch invariance guarantees
4. Prefix caching functionality in multi-chat scenarios
5. Prefix caching performance improvements for long-context workloads
6. Model accuracy with and without prefix caching enabled
7. Multimodal (vision-language) support with Paged Attention

Models Covered
Text Models : meta-llama/Llama-3.1-8B-Instruct
Multimodal Models : Qwen/Qwen2.5-VL-3B-Instruct