### PR TITLE
Use V1 model runner for v0.28 PYT warmup

### DIFF
--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -202,6 +202,7 @@ class QaicWorkerPyt(QaicWorker):
             is_driver_worker=is_driver_worker,
         )
         assert self.model_config.enforce_eager
+        self.use_v2_model_runner = False
         self.parallel_config.disable_custom_all_reduce = True
         self.profiler_config = vllm_config.profiler_config
 


### PR DESCRIPTION
## Summary

Restore the normal vLLM kernel warmup path for QAIC PYT and explicitly select the V1 model runner:

- Set `QaicWorkerPyt.use_v2_model_runner = False`.
- Keep `kernel_warmup(self)` enabled.

v0.28 invokes `kernel_warmup()` from `QaicWorkerPyt.compile_or_warm_up_model()`. QAIC eager does not support the V2 model runner, so explicitly selecting V1 prevents the missing `use_v2_model_runner` state that previously caused EngineCore startup to fail.

## Dependency

Depends on #98. This PR is stacked on the v0.28 rebase and must merge after #98.