### PR TITLE
Accept output wheel file name as a command-line argument for build_wheels script

### DIFF
--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -60,6 +60,11 @@
 #   docker buildx build --target wheel -t vllm-qaic-aot-wheel \
 #     --output type=local,dest=./dist/aot .
 #
+#   # Wheel with an overridden filename:
+#   docker buildx build --target wheel -t vllm-qaic-aot-wheel \
+#     --build-arg WHEEL_NAME=vllm_qaic-1.22.0+aot-py3-none-any.whl \
+#     --output type=local,dest=./dist/aot .
+#
 #   # Any target — also build vllm's experimental Rust OpenAI frontend
 #   # (vllm-rs). See docs/installation.md for known caveats.
 #   docker build --target release --build-arg VLLM_BUILD_RUST=1 \
@@ -135,6 +140,12 @@ ARG VLLM_QAIC_BRANCH=""
 # Dev-specific
 # ---------------------------------------------------------------------------
 ARG QEFF_PR=""    # if set, overrides QEFF_BRANCH for editable QEfficient install
+
+# ---------------------------------------------------------------------------
+# Wheel-specific — WHEEL_NAME renames the built wheel before it is exported
+# (empty = keep uv build's own name).
+# ---------------------------------------------------------------------------
+ARG WHEEL_NAME=""
 
 # ---------------------------------------------------------------------------
 # Pinned uv binary — FROM supports ARG substitution, COPY --from does not.
@@ -531,17 +542,41 @@ CMD ["bash"]
 #
 #   docker buildx build --target wheel -f docker/Dockerfile.aot \
 #     --output type=local,dest=./dist/aot .
+#
+#   # Custom wheel filename:
+#   docker buildx build --target wheel -f docker/Dockerfile.aot \
+#     --build-arg WHEEL_NAME=vllm_qaic-1.22.0+aot-py3-none-any.whl \
+#     --output type=local,dest=./dist/aot .
 # ===========================================================================
 FROM aot-base AS wheel-builder
 
 ARG VLLM_VERSION="0.23.0"
 ARG VLLM_QAIC_VERSION="1.22"
+ARG WHEEL_NAME=""
 
+# WHEEL_NAME rename: the wheel's own name comes from setup.py's package name
+# and version, so overriding the filename is a post-build mv. Only the filename
+# changes — the .dist-info inside still carries the real name/version. pip reads
+# the distribution and compatibility tags off the filename and requires the
+# distribution to match that metadata, so an arbitrary name exports fine but
+# may not be installable; scripts/build_wheels.sh warns about names pip would
+# reject. Failing when /out has no wheel keeps a silent no-op rename from
+# exporting an unrenamed artifact.
 COPY . /src/vllm-qaic
 RUN --mount=type=cache,sharing=locked,target=/var/cache/uv \
     TORCH_QAIC_INSTALLED=0 \
     VLLM_VERSION_OVERRIDE="${VLLM_VERSION}+aot${VLLM_QAIC_VERSION}" \
-    uv build --wheel --no-build-isolation --out-dir /out /src/vllm-qaic
+    uv build --wheel --no-build-isolation --out-dir /out /src/vllm-qaic && \
+    if [ -n "${WHEEL_NAME}" ]; then \
+        built="$(find /out -maxdepth 1 -name '*.whl' -print -quit)"; \
+        if [ -z "${built}" ]; then \
+            echo "ERROR: no wheel found in /out to rename" >&2; exit 1; \
+        fi; \
+        if [ "${built}" != "/out/${WHEEL_NAME}" ]; then \
+            mv "${built}" "/out/${WHEEL_NAME}" && \
+            echo "=== Wheel renamed: $(basename "${built}") -> ${WHEEL_NAME} ==="; \
+        fi; \
+    fi
 
 FROM scratch AS wheel
 COPY --from=wheel-builder /out /

--- a/docker/Dockerfile.pyt
+++ b/docker/Dockerfile.pyt
@@ -62,6 +62,12 @@
 #     --build-arg PYTHON_VERSION=3.11 --build-arg QAIC_DEVICE_ARCH=v81 \
 #     --output type=local,dest=./dist/pyt/py311 .
 #
+#   # Wheel with an overridden filename:
+#   docker buildx build --target wheel -f docker/Dockerfile.pyt \
+#     --build-arg PYTHON_VERSION=3.11 \
+#     --build-arg WHEEL_NAME=vllm_qaic-1.22.0+pyt-cp311-cp311-linux_x86_64.whl \
+#     --output type=local,dest=./dist/pyt/py311 .
+#
 #   # Any target — also build vllm's experimental Rust OpenAI frontend
 #   # (vllm-rs). See docs/installation.md for known caveats.
 #   docker build --target release -f docker/Dockerfile.pyt \
@@ -130,6 +136,12 @@ ARG VLLM_QAIC_GIT_REF="v0.23.0"
 # ---------------------------------------------------------------------------
 ARG VLLM_QAIC_PR=""
 ARG VLLM_QAIC_BRANCH=""
+
+# ---------------------------------------------------------------------------
+# Wheel-specific — WHEEL_NAME renames the built wheel before it is exported
+# (empty = keep uv build's own name).
+# ---------------------------------------------------------------------------
+ARG WHEEL_NAME=""
 
 # ---------------------------------------------------------------------------
 # Pinned uv binary — FROM supports ARG substitution, COPY --from does not.
@@ -480,18 +492,42 @@ CMD ["bash"]
 #   docker buildx build --target wheel -f docker/Dockerfile.pyt \
 #     --build-arg PYTHON_VERSION=3.11 --build-arg QAIC_DEVICE_ARCH=v81 \
 #     --output type=local,dest=./dist/pyt/py311 .
+#
+#   # Custom wheel filename:
+#   docker buildx build --target wheel -f docker/Dockerfile.pyt \
+#     --build-arg WHEEL_NAME=vllm_qaic-1.22.0+pyt-cp311-cp311-linux_x86_64.whl \
+#     --output type=local,dest=./dist/pyt/py311 .
 # ===========================================================================
 FROM pyt-base AS wheel-builder
 
 ARG VLLM_VERSION="0.23.0"
 ARG VLLM_QAIC_VERSION="1.22"
 ARG QAIC_DEVICE_ARCH="v68"
+ARG WHEEL_NAME=""
 
+# WHEEL_NAME rename: the wheel's own name comes from setup.py's package name
+# and version, so overriding the filename is a post-build mv. Only the filename
+# changes — the .dist-info inside still carries the real name/version. pip reads
+# the distribution and compatibility tags off the filename and requires the
+# distribution to match that metadata, so an arbitrary name exports fine but
+# may not be installable; scripts/build_wheels.sh warns about names pip would
+# reject. Failing when /out has no wheel keeps a silent no-op rename from
+# exporting an unrenamed artifact.
 COPY . /src/vllm-qaic
 RUN --mount=type=cache,sharing=locked,target=/var/cache/uv \
     QAIC_DEVICE_ARCH="${QAIC_DEVICE_ARCH}" \
     VLLM_VERSION_OVERRIDE="${VLLM_VERSION}+pyt${VLLM_QAIC_VERSION}" \
-    uv build --wheel --no-build-isolation --out-dir /out /src/vllm-qaic
+    uv build --wheel --no-build-isolation --out-dir /out /src/vllm-qaic && \
+    if [ -n "${WHEEL_NAME}" ]; then \
+        built="$(find /out -maxdepth 1 -name '*.whl' -print -quit)"; \
+        if [ -z "${built}" ]; then \
+            echo "ERROR: no wheel found in /out to rename" >&2; exit 1; \
+        fi; \
+        if [ "${built}" != "/out/${WHEEL_NAME}" ]; then \
+            mv "${built}" "/out/${WHEEL_NAME}" && \
+            echo "=== Wheel renamed: $(basename "${built}") -> ${WHEEL_NAME} ==="; \
+        fi; \
+    fi
 
 FROM scratch AS wheel
 COPY --from=wheel-builder /out /

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -271,6 +271,7 @@ All `ARG`s are global (declared before the first `FROM`) and re-declared inside 
 | `VLLM_QAIC_PR` | *(empty)* | `ci` target: PR number to fetch (takes priority over `VLLM_QAIC_BRANCH`) |
 | `VLLM_QAIC_BRANCH` | *(empty)* | `ci` target: branch to fetch |
 | `QEFF_PR` | *(empty)* | `dev` target: QEfficient PR to install editable (overrides `QEFF_BRANCH`) |
+| `WHEEL_NAME` | *(empty)* | `wheel` target: rename the built wheel to this filename before exporting it (empty = `uv build`'s own name). See [Overriding the wheel filename](#overriding-the-wheel-filename) |
 
 **`docker/Dockerfile.pyt`**
 
@@ -295,6 +296,7 @@ All `ARG`s are global (declared before the first `FROM`) and re-declared inside 
 | `VLLM_QAIC_GIT_REF` | `v0.23.0` | `release` target: vllm-qaic git tag/branch to clone |
 | `VLLM_QAIC_PR` | *(empty)* | `ci` target: PR number to fetch (takes priority over `VLLM_QAIC_BRANCH`) |
 | `VLLM_QAIC_BRANCH` | *(empty)* | `ci` target: branch to fetch |
+| `WHEEL_NAME` | *(empty)* | `wheel` target: rename the built wheel to this filename before exporting it (empty = `uv build`'s own name). See [Overriding the wheel filename](#overriding-the-wheel-filename) |
 
 ### Build commands
 
@@ -372,6 +374,27 @@ Output locations:
 |---|---|
 | AOT | `dist/aot/vllm_qaic-*aot*-py3-none-any.whl` |
 | PYT | `dist/pyt/py312/vllm_qaic-*pyt*-cp312-cp312-linux_x86_64.whl` |
+
+#### Overriding the wheel filename
+
+`--wheel-name` replaces the filename `uv build` would generate. The script forwards it to the Dockerfile's `wheel` stage as the `WHEEL_NAME` build-arg, and that stage renames the wheel before BuildKit exports it — so the file that lands in `--outdir` already carries the custom name:
+
+```bash
+# AOT wheel as dist/aot/vllm_qaic-1.22.0+aot-py3-none-any.whl
+./scripts/build_wheels.sh aot --outdir ./dist \
+    --wheel-name vllm_qaic-1.22.0+aot-py3-none-any.whl
+
+# PYT wheel as dist/pyt/py312/vllm_qaic-1.22.0+pyt-cp312-cp312-linux_x86_64.whl
+./scripts/build_wheels.sh pyt --outdir ./dist \
+    --wheel-name vllm_qaic-1.22.0+pyt-cp312-cp312-linux_x86_64.whl
+```
+
+Notes:
+
+- **Requires an explicit `aot` or `pyt` target.** One filename cannot name two wheels, so `--wheel-name` is rejected with `both` — including the implicit default when no target is given.
+- Must be a bare filename ending in `.whl` (letters, digits, `.`, `_`, `+`, `-`). The directory still comes from `--outdir`.
+- Only the filename changes; the `.dist-info` inside the wheel still carries the real `vllm_qaic` name and version. pip reads the distribution, version and compatibility tags off the filename and requires the distribution to match that metadata. The script warns (but still builds) when the name isn't a valid wheel filename — `<distribution>-<version>[-<build>]-<pytag>-<abitag>-<plattag>.whl`, no `-` inside a field and a build tag starting with a digit — or when its distribution part isn't `vllm_qaic`. Such a wheel is fine as an archived artifact but `pip install` will reject it.
+- A renamed wheel no longer matches the `vllm_qaic-*aot*.whl` / `vllm_qaic-*pyt*.whl` globs used by `install.sh` and by the manual `pip install` commands below. Install it by its explicit path, or keep an `*aot*`/`*pyt*` substring in the name.
 
 ### Step 2a — Install from wheel using `install.sh`
 

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -16,7 +16,8 @@
 # Usage:
 #   ./scripts/build_wheels.sh [aot|pyt|both] [--pyver 3.10|3.11|3.12]
 #                              [--outdir <dir>] [--device-arch v68|v81]
-#                              [--base-image <image:tag>] [--dry-run]
+#                              [--base-image <image:tag>]
+#                              [--wheel-name <name.whl>] [--dry-run]
 
 set -euo pipefail
 
@@ -27,7 +28,8 @@ usage() {
   cat << EOM
 Usage: build_wheels.sh [aot|pyt|both] [--pyver 3.10|3.11|3.12]
                         [--outdir <dir>] [--device-arch v68|v81]
-                        [--base-image <image:tag>] [--dry-run]
+                        [--base-image <image:tag>]
+                        [--wheel-name <name.whl>] [--dry-run]
 
 aot|pyt|both   Wheel(s) to build (default: both).
 --pyver        Python version to build with: 3.10, 3.11, or 3.12
@@ -40,6 +42,13 @@ aot|pyt|both   Wheel(s) to build (default: both).
 --base-image   Override the QAIC SDK base image (passed through as the
                BASE_IMAGE build-arg; default: each Dockerfile's own ARG
                default).
+--wheel-name   Override the generated wheel's filename (passed through as the
+               WHEEL_NAME build-arg; the Dockerfile's wheel stage renames the
+               wheel before exporting it). Bare filename ending in .whl — the
+               directory is still controlled by --outdir. Requires an explicit
+               aot or pyt target; not usable with 'both' (one name cannot
+               apply to two wheels). Default: uv build's own name,
+               vllm_qaic-<version>-<py>-<abi>-<platform>.whl.
 --dry-run      Print the docker buildx commands without running them.
 EOM
 }
@@ -54,6 +63,7 @@ PYTHON_VERSION="${DEFAULT_PYTHON_VERSION}"
 OUT_DIR="${REPO_ROOT}/dist"
 DEVICE_ARCH="${DEFAULT_DEVICE_ARCH}"
 BASE_IMAGE=""
+WHEEL_NAME=""
 DRY_RUN="OFF"
 
 if [[ $# -gt 0 && "$1" != --* ]]; then
@@ -67,6 +77,7 @@ while [[ $# -gt 0 ]]; do
         --outdir) OUT_DIR="$2"; shift 2 ;;
         --device-arch) DEVICE_ARCH="$2"; shift 2 ;;
         --base-image) BASE_IMAGE="$2"; shift 2 ;;
+        --wheel-name) WHEEL_NAME="$2"; shift 2 ;;
         --dry-run) DRY_RUN="ON"; shift ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
@@ -88,6 +99,50 @@ if [[ "${DEVICE_ARCH}" != "v68" && "${DEVICE_ARCH}" != "v81" ]]; then
     exit 1
 fi
 
+# --wheel-name names exactly one wheel file, so it can't cover a 'both' build
+# (which produces an aot and a pyt wheel). 'both' is also the default target,
+# so an override with no explicit target lands here too.
+if [[ -n "${WHEEL_NAME}" && "${BUILD_TARGET}" == "both" ]]; then
+    echo "ERROR: --wheel-name cannot be used with target 'both' — one filename" >&2
+    echo "       cannot name two wheels. Pass an explicit 'aot' or 'pyt' target," >&2
+    echo "       e.g. ./scripts/build_wheels.sh aot --wheel-name ${WHEEL_NAME}" >&2
+    exit 1
+fi
+
+# Restrict to the character set legal in a wheel filename (PEP 427): rejects
+# path separators (--outdir owns the directory) and anything that could break
+# out of the quoting in the Dockerfile's rename step.
+if [[ -n "${WHEEL_NAME}" && ! "${WHEEL_NAME}" =~ ^[A-Za-z0-9._+-]+\.whl$ ]]; then
+    echo "ERROR: --wheel-name must be a bare filename ending in .whl, using only" >&2
+    echo "       letters, digits, '.', '_', '+' and '-' (got '${WHEEL_NAME}')" >&2
+    exit 1
+fi
+
+# Renaming touches only the filename, not the .dist-info inside the wheel. pip
+# reads the distribution, version and compatibility tags off the filename and
+# requires the distribution to match that metadata — so a name that isn't a
+# PEP 427 wheel filename, or whose distribution part isn't vllm_qaic, still
+# builds and exports fine but cannot be pip-installed. Warn, don't fail: a
+# custom name is legitimate for archiving or republishing the artifact.
+if [[ -n "${WHEEL_NAME}" ]]; then
+    # <distribution>-<version>[-<build>]-<pytag>-<abitag>-<plattag>.whl — no
+    # field may contain '-', and a build tag must start with a digit.
+    WHEEL_NAME_RE="^[A-Za-z0-9_.]+-[A-Za-z0-9_.!+]+(-[0-9][A-Za-z0-9_.]*)?"
+    WHEEL_NAME_RE+="-[A-Za-z0-9_.]+-[A-Za-z0-9_.]+-[A-Za-z0-9_.]+\.whl$"
+
+    if [[ ! "${WHEEL_NAME}" =~ ${WHEEL_NAME_RE} ]]; then
+        echo "WARNING: '${WHEEL_NAME}' is not a valid wheel filename (expected" >&2
+        echo "         <distribution>-<version>[-<build>]-<pytag>-<abitag>-<plattag>.whl," >&2
+        echo "         e.g. vllm_qaic-1.22.0-py3-none-any.whl). It will be built and" >&2
+        echo "         exported under that name, but pip cannot parse or install it." >&2
+    elif [[ "${WHEEL_NAME}" != vllm_qaic-* ]]; then
+        echo "WARNING: '${WHEEL_NAME}' does not name distribution 'vllm_qaic'. The" >&2
+        echo "         wheel's internal metadata still says vllm_qaic, and pip rejects" >&2
+        echo "         a wheel whose filename disagrees with it. Fine for archiving" >&2
+        echo "         under a custom name; 'pip install' of it will fail." >&2
+    fi
+fi
+
 PYVER_TAG="py${PYTHON_VERSION//./}"
 
 run_echo() {
@@ -105,6 +160,7 @@ echo "PYTHON_VERSION : ${PYTHON_VERSION}"
 echo "MODE           : ${BUILD_TARGET}"
 echo "DEVICE_ARCH    : ${DEVICE_ARCH} (pyt only)"
 echo "BASE_IMAGE     : ${BASE_IMAGE:-<Dockerfile default>}"
+echo "WHEEL_NAME     : ${WHEEL_NAME:-<uv build default>}"
 echo "OUT_DIR        : ${OUT_DIR}"
 echo "================================================================"
 
@@ -113,12 +169,19 @@ if [ -n "${BASE_IMAGE}" ]; then
     BASE_IMAGE_ARGS=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
 fi
 
+# Left empty unless overridden, so the wheel stage keeps uv build's own name.
+WHEEL_NAME_ARGS=()
+if [ -n "${WHEEL_NAME}" ]; then
+    WHEEL_NAME_ARGS=(--build-arg "WHEEL_NAME=${WHEEL_NAME}")
+fi
+
 build_aot_wheel() {
     echo ""
     echo "=== Building AOT wheel (pure Python, py3-none-any — pyver-independent) ==="
     run_echo docker buildx build --target wheel -f "${DOCKER_DIR}/Dockerfile.aot" \
         --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
         "${BASE_IMAGE_ARGS[@]}" \
+        "${WHEEL_NAME_ARGS[@]}" \
         --output "type=local,dest=${OUT_DIR}/aot" \
         "${REPO_ROOT}"
 }
@@ -130,6 +193,7 @@ build_pyt_wheel() {
         --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
         --build-arg QAIC_DEVICE_ARCH="${DEVICE_ARCH}" \
         "${BASE_IMAGE_ARGS[@]}" \
+        "${WHEEL_NAME_ARGS[@]}" \
         --output "type=local,dest=${OUT_DIR}/pyt/${PYVER_TAG}" \
         "${REPO_ROOT}"
 }
@@ -160,13 +224,23 @@ report_wheel() {
     fi
 }
 
+# An override replaces the whole filename, so the result check looks for that
+# exact name rather than the default glob. Safe to set both patterns — the
+# validation above rejects --wheel-name for anything but a single target.
+AOT_WHEEL_NAME="vllm_qaic-*aot*.whl"
+PYT_WHEEL_NAME="vllm_qaic-*pyt*.whl"
+if [ -n "${WHEEL_NAME}" ]; then
+    AOT_WHEEL_NAME="${WHEEL_NAME}"
+    PYT_WHEEL_NAME="${WHEEL_NAME}"
+fi
+
 if [ "${DRY_RUN}" == "ON" ]; then
     echo "  (dry-run: no wheels were actually built)"
 elif [ "${BUILD_TARGET}" == "aot" ] || [ "${BUILD_TARGET}" == "both" ]; then
-    report_wheel "aot" "${OUT_DIR}/aot/vllm_qaic-*aot*.whl"
+    report_wheel "aot" "${OUT_DIR}/aot/${AOT_WHEEL_NAME}"
 fi
 if [ "${DRY_RUN}" == "OFF" ] && { [ "${BUILD_TARGET}" == "pyt" ] || [ "${BUILD_TARGET}" == "both" ]; }; then
-    report_wheel "pyt" "${OUT_DIR}/pyt/${PYVER_TAG}/vllm_qaic-*pyt*.whl"
+    report_wheel "pyt" "${OUT_DIR}/pyt/${PYVER_TAG}/${PYT_WHEEL_NAME}"
 fi
 
 echo "================================================================"


### PR DESCRIPTION
This change allows the user to externally override the name of the generated wheel file with build_wheels.sh. It requires that the wheel type should be passed and that the type should either be "aot" or "pyt" but not "both".