### PR TITLE
feat(qaic): add Cohere ASR transcription support

### DIFF
--- a/docs/docs/user_guide/features/encoder_decoder.md
+++ b/docs/docs/user_guide/features/encoder_decoder.md
@@ -1,6 +1,6 @@
 # Encoder-Decoder Models
 
-QAIC supports encoder-decoder architectures, primarily Whisper for audio transcription.
+QAIC supports encoder-decoder architectures for audio transcription.
 
 ## Whisper
 
@@ -56,3 +56,85 @@ for output in outputs:
     - Currently validated for Whisper family
     - Continuous batching not supported
     - Encoder context length determined at compilation time
+
+## Cohere ASR
+
+Cohere Transcribe runs through vLLM's OpenAI-compatible transcription endpoint.
+This initial integration supports one transcription at a time (batch size 1).
+Use `CohereLabs/cohere-transcribe-03-2026` for the multilingual model or
+`CohereLabs/cohere-transcribe-arabic-07-2026` for the separately trained Arabic
+model. A precompiled QPC must come from the same checkpoint that is served.
+
+### Use an existing QPC
+
+```bash
+export QAIC_VISIBLE_DEVICES=0
+export VLLM_QAIC_QPC_PATH=/path/to/cohere-asr/qpc
+
+vllm serve CohereLabs/cohere-transcribe-03-2026 \
+  --hf-overrides '{"max_source_positions":438}' \
+  --max-num-seqs 1 \
+  --max-model-len 512 \
+  --max-num-batched-tokens 3504 \
+  --long-prefill-token-threshold 512 \
+  --limit-mm-per-prompt '{"audio":1}' \
+  --mm-processor-cache-gb 0 \
+  --no-enable-prefix-caching \
+  --no-async-scheduling \
+  --additional-config '{"device_group":[0],"override_qaic_config":{"num_cores":8,"task":"transcription"}}'
+```
+
+### Build a QPC when the server starts
+
+Automatic compilation requires a QEfficient installation with Cohere ASR
+support. Until that support is released, install it from
+[QEfficient PR #1275](https://github.com/quic/efficient-transformers/pull/1275).
+
+```bash
+export QAIC_VISIBLE_DEVICES=0
+unset VLLM_QAIC_QPC_PATH
+
+vllm serve CohereLabs/cohere-transcribe-03-2026 \
+  --hf-overrides '{"max_source_positions":438}' \
+  --max-num-seqs 1 \
+  --max-model-len 512 \
+  --max-num-batched-tokens 3504 \
+  --long-prefill-token-threshold 512 \
+  --limit-mm-per-prompt '{"audio":1}' \
+  --mm-processor-cache-gb 0 \
+  --no-enable-prefix-caching \
+  --no-async-scheduling \
+  --additional-config '{"device_group":[0],"override_qaic_config":{"num_cores":8,"task":"transcription"}}'
+```
+
+The server exports and compiles the served checkpoint before accepting requests.
+
+Transcribe an audio file with the included client:
+
+```bash
+python examples/qaic_cohere_asr.py \
+  --file-path /path/to/audio.wav \
+  --language en
+```
+
+For the validated Arabic checkpoint, serve
+`CohereLabs/cohere-transcribe-arabic-07-2026` and pass that same model name with
+`--model` to the client together with `--language ar`. The endpoint selects the
+language-specific decoder prefix; callers should not construct model prompts.
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `max_num_seqs` | `1` | Validated static QPC batch size |
+| `max_model_len` | `512` | Decoder context length compiled into the QPC |
+| `max_num_batched_tokens` | `3504` | Encoder feature-frame binding compiled into the QPC |
+| `hf_overrides` | `{"max_source_positions": 438}` | Cohere encoder position setting used for the QPC |
+| `limit_mm_per_prompt` | `{"audio": 1}` | One audio input per transcription request |
+| `VLLM_QAIC_QPC_PATH` | QPC directory | Reuses the matching precompiled QPC |
+| `num_cores` | `8` | Validated QPC core count |
+
+!!! warning "Constraints"
+    - AOT mode only
+    - Batch size 1 only
+    - Continuous batching is not supported
+    - The QPC dimensions above must match the supplied QPC
+    - The served checkpoint and QPC checkpoint must match; do not compare WER across different checkpoints

--- a/docs/docs/user_guide/features/index.md
+++ b/docs/docs/user_guide/features/index.md
@@ -30,7 +30,7 @@ Status of vLLM features on Qualcomm Cloud AI hardware.
 | Disaggregated serving | ✅ | ❌ | xEyPzD prefill/decode split |
 | Multimodal (VLM) | ✅ | 🧪 | kv_offload architecture |
 | Embedding models | ✅ | ❌ | Pooling tasks (Score, embed, classify, rerank) |
-| Encoder-decoder | ✅ | ❌ | Whisper |
+| Encoder-decoder | ✅ | ❌ | Whisper, Cohere ASR (BS1) |
 | Tensor parallelism | ✅ | ✅ | Across QIDs |
 | Pipeline parallelism | ✅ | ❌ | Across QIDs |
 

--- a/docs/docs/user_guide/models/supported_models_aot.md
+++ b/docs/docs/user_guide/models/supported_models_aot.md
@@ -99,6 +99,7 @@ Support varies by QPC mode (Single vs Dual). Dual QPC uses the `kv_offload` arch
 | Architecture | Model Family | Representative Models |
 |---|---|---|
 | **Whisper** | Whisper | [openai/whisper-tiny](https://huggingface.co/openai/whisper-tiny), [openai/whisper-base](https://huggingface.co/openai/whisper-base), [openai/whisper-small](https://huggingface.co/openai/whisper-small), [openai/whisper-medium](https://huggingface.co/openai/whisper-medium), [openai/whisper-large](https://huggingface.co/openai/whisper-large), [openai/whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo) |
+| **CohereAsrForConditionalGeneration** | Cohere Transcribe | [CohereLabs/cohere-transcribe-03-2026](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026), [CohereLabs/cohere-transcribe-arabic-07-2026](https://huggingface.co/CohereLabs/cohere-transcribe-arabic-07-2026) |
 
 ---
 

--- a/examples/qaic_cohere_asr.py
+++ b/examples/qaic_cohere_asr.py
@@ -1,0 +1,64 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+
+"""Transcribe one audio file through a running Cohere ASR vLLM server.
+
+Start the server with the Cohere ASR QPC configuration documented in
+``docs/docs/user_guide/features/encoder_decoder.md``, then run:
+
+    python examples/qaic_cohere_asr.py --file-path /path/to/audio.wav --language en
+"""
+
+import argparse
+from pathlib import Path
+
+from openai import OpenAI
+
+
+DEFAULT_MODEL = "CohereLabs/cohere-transcribe-03-2026"
+DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file-path", type=Path, required=True, help="Audio file to transcribe"
+    )
+    parser.add_argument(
+        "--language",
+        required=True,
+        help=(
+            "BCP-47 language code passed to the transcription endpoint, "
+            "for example en or ar"
+        ),
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help="Served Cohere ASR model ID"
+    )
+    parser.add_argument(
+        "--base-url", default=DEFAULT_BASE_URL, help="vLLM OpenAI API base URL"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.file_path.is_file():
+        raise ValueError(f"Audio file does not exist: {args.file_path}")
+
+    client = OpenAI(api_key="EMPTY", base_url=args.base_url)
+    with args.file_path.open("rb") as audio_file:
+        transcription = client.audio.transcriptions.create(
+            file=audio_file,
+            model=args.model,
+            language=args.language,
+            response_format="json",
+            temperature=0.0,
+        )
+    print(transcription.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -23,7 +23,7 @@ def test_cohere_asr_processor_extracts_audio_once(monkeypatch):
     from types import SimpleNamespace
 
     from vllm.model_executor.models.cohere_asr import CohereASRMultiModalProcessor
-    from vllm_qaic.model_loader.qaic_custom_mm_processor import (
+    from vllm_qaic.model_loader.qaic_cohere_asr_processor import (
         QaicCohereASRMultiModalProcessor,
     )
 

--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -1,0 +1,74 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+
+import importlib.metadata
+
+import numpy as np
+import torch
+from transformers import BatchFeature
+
+
+def test_general_plugin_remains_independent_of_cohere_asr():
+    plugins = {
+        entry_point.name: entry_point.value
+        for entry_point in importlib.metadata.entry_points(group="vllm.general_plugins")
+    }
+    assert plugins["qaic_kv_connector"] == "vllm_qaic:register_connector"
+    assert "qaic" not in plugins
+
+
+def test_cohere_asr_processor_extracts_audio_once(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm.model_executor.models.cohere_asr import CohereASRMultiModalProcessor
+    from vllm_qaic.model_loader.qaic_custom_mm_processor import (
+        QaicCohereASRMultiModalProcessor,
+    )
+
+    calls = {"vllm": 0, "native": 0}
+
+    def tokenize_only(self, prompt, mm_data, mm_kwargs, tok_kwargs):
+        calls["vllm"] += 1
+        assert mm_data == {}
+        return BatchFeature({"input_ids": torch.tensor([[7]])})
+
+    class NativeFeatureExtractor:
+        sampling_rate = 16_000
+        max_audio_clip_s = 35.0
+        overlap_chunk_second = 5.0
+
+        def __call__(self, audios, **kwargs):
+            calls["native"] += 1
+            assert len(audios) == 1
+            return BatchFeature(
+                {
+                    "input_features": torch.ones((1, 4, 128)),
+                    "attention_mask": torch.ones((1, 4), dtype=torch.int64),
+                }
+            )
+
+    monkeypatch.setattr(
+        CohereASRMultiModalProcessor, "_call_hf_processor", tokenize_only
+    )
+    processor = object.__new__(QaicCohereASRMultiModalProcessor)
+    processor.info = SimpleNamespace(
+        get_hf_config=lambda: SimpleNamespace(max_audio_clip_s=35.0)
+    )
+    feature_extractor = NativeFeatureExtractor()
+    processor.__dict__["_qaic_hf_processor"] = SimpleNamespace(
+        feature_extractor=feature_extractor
+    )
+
+    outputs = processor._call_hf_processor(
+        "prompt",
+        {"audios": [np.zeros(16_000, dtype=np.float32)]},
+        {},
+        {},
+    )
+
+    assert calls == {"vllm": 1, "native": 1}
+    assert outputs["input_features"].shape == (1, 128, 4)
+    np.testing.assert_array_equal(outputs["length"], [4])
+    assert feature_extractor.overlap_chunk_second == 5.0

--- a/vllm_qaic/model_loader/qaic.py
+++ b/vllm_qaic/model_loader/qaic.py
@@ -134,7 +134,7 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
         self.config = config
         self.vocab_size = config.get_text_config().vocab_size
         # `long_prefill_token_threshold` will define prefill chunk length
-        if self.config.model_type == "whisper":
+        if self.config.model_type in ("whisper", "cohere_asr"):
             # Encoder-decoder models have chunked prefill disabled by vllm,
             # but QAIC still requires a prefill sequence length.
             # For whisper, the prefill sequence length is fixed to 1.
@@ -745,6 +745,16 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                     (1, self.prefill_seq_len), self.config.decoder_start_token_id
                 )
                 pids = pids[..., : self.prefill_seq_len]
+            elif self.config.model_type == "cohere_asr":
+                bos_token_id = getattr(self.config, "bos_token_id", None)
+                if (
+                    bos_token_id is not None
+                    and iids.size > 1
+                    and iids[0] == bos_token_id
+                ):
+                    iids = iids[1:]
+                    pids = pids[..., 1:]
+                    pids = pids - pids[..., :1]
 
             # create chunk inputs
             chunk_inputs = dict()
@@ -756,6 +766,14 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
                 chunk_inputs["lora_ids"] = lora_index
             if mm_kwargs_list and (mm_kwargs := mm_kwargs_list[i]):
                 chunk_inputs.update(mm_kwargs)
+            if self.config.model_type == "cohere_asr":
+                # QEff keeps the encoder feature length while decode uses a
+                # one-frame dummy feature tensor. The cross-attention mask is
+                # derived from this original request length.
+                self.default_mm_kwargs["feature_lengths"] = chunk_inputs[
+                    "feature_lengths"
+                ].copy()
+                self.decode_batch_inputs.update(self.default_mm_kwargs)
             # chunk the request
             n_chunks: int = iids.shape[-1] // self.prefill_seq_len
 
@@ -764,6 +782,12 @@ class QaicCausalLM(nn.Module, SupportsLoRA):
 
             prefill_ccl_id = 0
             for chunk in range(n_chunks):
+                if self.config.model_type == "cohere_asr" and chunk > 0:
+                    # Cohere's transcription prefix contains multiple decoder
+                    # tokens. The QPC encoder runs only with the first token;
+                    # its decode specialization reuses retained cross-attention
+                    # state for the remaining prefix tokens.
+                    chunk_inputs.update(self.default_mm_kwargs)
                 lower_idx = int(chunk * self.prefill_seq_len)
                 upper_idx = int((chunk + 1) * self.prefill_seq_len)
                 chunk_inputs["input_ids"] = iids[lower_idx:upper_idx].reshape(
@@ -1685,7 +1709,21 @@ def get_hf_model(
         "seq_classify": QEFFAutoModelForSequenceClassification,
     }
     hf_config = model_config.hf_config
-    if hf_config.model_type in _CONFIG_REGISTRY or not is_json_serializable(hf_config):
+    qeff_trust_remote_code = model_config.trust_remote_code
+    if hf_config.model_type == "cohere_asr":
+        # QEff's Cohere ASR transforms target the native Transformers classes.
+        # Do not replace them with duplicate classes from Hub model code.
+        from transformers import AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(
+            model_config.model,
+            trust_remote_code=False,
+            revision=model_config.revision,
+        )
+        qeff_trust_remote_code = False
+    elif (
+        hf_config.model_type in _CONFIG_REGISTRY or not is_json_serializable(hf_config)
+    ):
         # If vllm uses a custom model config class,
         # convert it back to the transformers config class
         from transformers import AutoConfig
@@ -1710,7 +1748,7 @@ def get_hf_model(
             "continuous_batching", True
         ),
         "qaic_config": qaic_config,
-        "trust_remote_code": model_config.trust_remote_code,
+        "trust_remote_code": qeff_trust_remote_code,
         "revision": model_config.revision,
         "code_revision": model_config.code_revision,
         "attn_implementation": "eager",
@@ -1724,7 +1762,7 @@ def get_hf_model(
 
     model_type = "lora" if lora_config else "default"
     if model_config.is_multimodal_model:
-        if model_config.hf_config.model_type == "whisper":
+        if model_config.hf_config.model_type in ("whisper", "cohere_asr"):
             model_type = "speech"
             del args["kv_offload"]
         elif model_config.hf_config.model_type != "internvl_chat":

--- a/vllm_qaic/model_loader/qaic_cohere_asr_processor.py
+++ b/vllm_qaic/model_loader/qaic_cohere_asr_processor.py
@@ -1,0 +1,68 @@
+# ------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# ------------------------------------------------------------------
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from functools import cached_property
+
+from transformers import AutoProcessor, BatchFeature
+
+from vllm.model_executor.models.cohere_asr import (
+    CohereASRDummyInputsBuilder,
+    CohereASRMultiModalProcessor,
+    CohereASRProcessingInfo,
+    CohereAsrForConditionalGeneration,
+)
+
+
+class QaicCohereASRMultiModalProcessor(CohereASRMultiModalProcessor):
+    """Use Cohere's HF processor so QPC inputs match QEff export semantics."""
+
+    @cached_property
+    def _qaic_hf_processor(self):
+        model_config = self.info.ctx.model_config
+        return AutoProcessor.from_pretrained(
+            model_config.model,
+            revision=model_config.revision,
+            trust_remote_code=False,
+        )
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        if not mm_data:
+            return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
+
+        # vLLM builds the request-specific decoder control prefix separately.
+        # Run its processor only for prompt tokenization, then extract audio
+        # once with the native HF feature extractor used by QEff.
+        processed_outputs = super()._call_hf_processor(
+            prompt, {}, mm_kwargs, tok_kwargs
+        )
+
+        feature_extractor = self._qaic_hf_processor.feature_extractor
+        feature_extractor.max_audio_clip_s = self.info.get_hf_config().max_audio_clip_s
+        audio_outputs = feature_extractor(
+            mm_data["audios"],
+            sampling_rate=feature_extractor.sampling_rate,
+            return_tensors="pt",
+        )
+        processed_outputs["input_features"] = audio_outputs[
+            "input_features"
+        ].transpose(1, 2).contiguous()
+        processed_outputs["length"] = audio_outputs["attention_mask"].sum(dim=-1)
+        return processed_outputs
+
+
+QAIC_COHERE_ASR_PROCESSOR = (
+    QaicCohereASRMultiModalProcessor,
+    CohereASRProcessingInfo,
+    CohereASRDummyInputsBuilder,
+    CohereAsrForConditionalGeneration,
+)

--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -7,14 +7,12 @@
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from functools import cached_property
 from typing import Any
 
 import torch
 from packaging.version import Version as _Version
 from qwen_vl_utils import smart_resize
 from transformers import (
-    AutoProcessor,
     BatchFeature,
     Qwen2VLImageProcessorFast,
     TensorType,
@@ -43,12 +41,6 @@ from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4MultiModalProcessor,
     Gemma4ProcessingInfo,
-)
-from vllm.model_executor.models.cohere_asr import (
-    CohereASRDummyInputsBuilder,
-    CohereASRMultiModalProcessor,
-    CohereASRProcessingInfo,
-    CohereAsrForConditionalGeneration,
 )
 from vllm.model_executor.models.transformers import (
     TransformersMultiModalForCausalLM,
@@ -112,50 +104,6 @@ Gemma4ForConditionalGeneration.get_placeholder_str = classmethod(
         "image" if modality == "image_embeds" else modality, i
     )
 )
-
-
-class QaicCohereASRMultiModalProcessor(CohereASRMultiModalProcessor):
-    """Use Cohere's HF processor so QPC inputs match QEff export semantics."""
-
-    @cached_property
-    def _qaic_hf_processor(self):
-        model_config = self.info.ctx.model_config
-        return AutoProcessor.from_pretrained(
-            model_config.model,
-            revision=model_config.revision,
-            trust_remote_code=False,
-        )
-
-    def _call_hf_processor(
-        self,
-        prompt: str,
-        mm_data: Mapping[str, object],
-        mm_kwargs: Mapping[str, object],
-        tok_kwargs: Mapping[str, object],
-    ) -> BatchFeature:
-        if not mm_data:
-            return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
-
-        # vLLM builds the request-specific decoder control prefix separately.
-        # Run its processor only for prompt tokenization, then extract audio
-        # once with the native HF feature extractor used by QEff.
-        processed_outputs = super()._call_hf_processor(
-            prompt, {}, mm_kwargs, tok_kwargs
-        )
-
-        feature_extractor = self._qaic_hf_processor.feature_extractor
-        feature_extractor.max_audio_clip_s = self.info.get_hf_config().max_audio_clip_s
-        audio_outputs = feature_extractor(
-            mm_data["audios"],
-            sampling_rate=feature_extractor.sampling_rate,
-            return_tensors="pt",
-        )
-        input_features = audio_outputs["input_features"]
-        processed_outputs["input_features"] = input_features.transpose(
-            1, 2
-        ).contiguous()
-        processed_outputs["length"] = audio_outputs["attention_mask"].sum(dim=-1)
-        return processed_outputs
 
 
 class QaicGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
@@ -728,6 +676,19 @@ class QaicQwen3_5MoeProcessingInfo(QaicQwen3VLProcessingInfo, Qwen3_5MoeProcessi
 
 
 def register_qaic_custom_mm_processor(model_type: str):
+    if model_type == "cohere_asr":
+        from vllm_qaic.model_loader.qaic_cohere_asr_processor import (
+            QAIC_COHERE_ASR_PROCESSOR,
+        )
+
+        processor_cls, info_cls, dummy_cls, model_cls = QAIC_COHERE_ASR_PROCESSOR
+        MULTIMODAL_REGISTRY.register_processor(
+            processor_cls,
+            info=info_cls,
+            dummy_inputs=dummy_cls,
+        )(model_cls)
+        return
+
     MODEL_PROCESSOR_MAP = {
         "qwen2_5_vl": (
             QaicQwen2_5_VLMultiModalProcessor,
@@ -770,12 +731,6 @@ def register_qaic_custom_mm_processor(model_type: str):
             Gemma4ProcessingInfo,
             Gemma4DummyInputsBuilder,
             Gemma4ForConditionalGeneration,
-        ),
-        "cohere_asr": (
-            QaicCohereASRMultiModalProcessor,
-            CohereASRProcessingInfo,
-            CohereASRDummyInputsBuilder,
-            CohereAsrForConditionalGeneration,
         ),
     }
 

--- a/vllm_qaic/model_loader/qaic_custom_mm_processor.py
+++ b/vllm_qaic/model_loader/qaic_custom_mm_processor.py
@@ -7,12 +7,18 @@
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from functools import cached_property
 from typing import Any
 
 import torch
 from packaging.version import Version as _Version
 from qwen_vl_utils import smart_resize
-from transformers import BatchFeature, Qwen2VLImageProcessorFast, TensorType
+from transformers import (
+    AutoProcessor,
+    BatchFeature,
+    Qwen2VLImageProcessorFast,
+    TensorType,
+)
 from transformers import __version__ as _transformers_version
 from transformers.image_processing_utils import select_best_resolution
 from transformers.image_transforms import group_images_by_shape, reorder_images
@@ -37,6 +43,12 @@ from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4MultiModalProcessor,
     Gemma4ProcessingInfo,
+)
+from vllm.model_executor.models.cohere_asr import (
+    CohereASRDummyInputsBuilder,
+    CohereASRMultiModalProcessor,
+    CohereASRProcessingInfo,
+    CohereAsrForConditionalGeneration,
 )
 from vllm.model_executor.models.transformers import (
     TransformersMultiModalForCausalLM,
@@ -100,6 +112,51 @@ Gemma4ForConditionalGeneration.get_placeholder_str = classmethod(
         "image" if modality == "image_embeds" else modality, i
     )
 )
+
+
+class QaicCohereASRMultiModalProcessor(CohereASRMultiModalProcessor):
+    """Use Cohere's HF processor so QPC inputs match QEff export semantics."""
+
+    @cached_property
+    def _qaic_hf_processor(self):
+        model_config = self.info.ctx.model_config
+        return AutoProcessor.from_pretrained(
+            model_config.model,
+            revision=model_config.revision,
+            trust_remote_code=False,
+        )
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        if not mm_data:
+            return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
+
+        # vLLM builds the request-specific decoder control prefix separately.
+        # Run its processor only for prompt tokenization, then extract audio
+        # once with the native HF feature extractor used by QEff.
+        processed_outputs = super()._call_hf_processor(
+            prompt, {}, mm_kwargs, tok_kwargs
+        )
+
+        feature_extractor = self._qaic_hf_processor.feature_extractor
+        feature_extractor.max_audio_clip_s = self.info.get_hf_config().max_audio_clip_s
+        audio_outputs = feature_extractor(
+            mm_data["audios"],
+            sampling_rate=feature_extractor.sampling_rate,
+            return_tensors="pt",
+        )
+        input_features = audio_outputs["input_features"]
+        processed_outputs["input_features"] = input_features.transpose(
+            1, 2
+        ).contiguous()
+        processed_outputs["length"] = audio_outputs["attention_mask"].sum(dim=-1)
+        return processed_outputs
+
 
 class QaicGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
     def _call_hf_processor(
@@ -713,6 +770,12 @@ def register_qaic_custom_mm_processor(model_type: str):
             Gemma4ProcessingInfo,
             Gemma4DummyInputsBuilder,
             Gemma4ForConditionalGeneration,
+        ),
+        "cohere_asr": (
+            QaicCohereASRMultiModalProcessor,
+            CohereASRProcessingInfo,
+            CohereASRDummyInputsBuilder,
+            CohereAsrForConditionalGeneration,
         ),
     }
 

--- a/vllm_qaic/model_loader/qaic_multimodal.py
+++ b/vllm_qaic/model_loader/qaic_multimodal.py
@@ -97,6 +97,8 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
             "vision_embeds",
             "image_position_ids",
         ]
+        if self.config.model_type == "cohere_asr":
+            mm_input_names.append("feature_lengths")
         for input_name in mm_input_names:
             if result := self.get_io_shape_and_dtype(input_name):
                 self.mm_input_info[input_name] = (result[0], result[1])
@@ -126,8 +128,27 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
             for k, v in self.mm_input_info.items():
                 if k == "input_features":
                     _shape = v[0].copy()
-                    _shape[-1] = 1 # Feature vector during decode is 1
-                    self.default_mm_kwargs["input_features"] = np.empty(_shape, dtype=v[1])
+                    _shape[-1] = 1  # Feature vector during decode is 1
+                    self.default_mm_kwargs["input_features"] = np.empty(
+                        _shape, dtype=v[1]
+                    )
+            self.decode_batch_inputs.update(self.default_mm_kwargs)
+        elif self.config.model_type == "cohere_asr":
+            input_features_info = self.mm_input_info.get("input_features")
+            feature_lengths_info = self.mm_input_info.get("feature_lengths")
+            if input_features_info is None or feature_lengths_info is None:
+                raise ValueError(
+                    "Cohere ASR QPC must expose input_features and "
+                    "feature_lengths bindings."
+                )
+            decode_shape = input_features_info[0].copy()
+            decode_shape[-1] = 1
+            self.default_mm_kwargs = {
+                "input_features": np.zeros(decode_shape, dtype=input_features_info[1]),
+                "feature_lengths": np.ones(
+                    feature_lengths_info[0], dtype=feature_lengths_info[1]
+                ),
+            }
             self.decode_batch_inputs.update(self.default_mm_kwargs)
 
     def _to_np(self, t, dtype: np.dtype | None = None) -> np.ndarray | list[np.ndarray]:
@@ -343,10 +364,60 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
             )
         elif "input_features" in kwargs:
             assert isinstance(kwargs["input_features"], torch.Tensor)
-            input_features_shape = self.mm_input_info["input_features"][0]
-            kwargs["input_features"] = kwargs["input_features"].reshape(
-                input_features_shape
-            )
+            if self.config.model_type == "cohere_asr":
+                input_features_info = self.mm_input_info.get("input_features")
+                feature_lengths_info = self.mm_input_info.get("feature_lengths")
+                feature_lengths = kwargs.pop("length", None)
+                if (
+                    input_features_info is None
+                    or feature_lengths_info is None
+                    or feature_lengths is None
+                ):
+                    raise ValueError(
+                        "Cohere ASR requires input_features, length, and matching "
+                        "QPC bindings."
+                    )
+                input_features = self._to_np(kwargs["input_features"])
+                feature_lengths = self._to_np(feature_lengths)
+                target_features_shape, target_features_dtype = input_features_info
+                target_lengths_shape, target_lengths_dtype = feature_lengths_info
+                if input_features.ndim == len(target_features_shape) - 1:
+                    input_features = np.expand_dims(input_features, axis=0)
+                if feature_lengths.ndim == 0:
+                    feature_lengths = feature_lengths.reshape(1)
+                if list(input_features.shape[:-1]) != target_features_shape[:-1]:
+                    raise ValueError(
+                        "Cohere ASR input feature shape does not match the QPC binding."
+                    )
+                if input_features.shape[-1] > target_features_shape[-1]:
+                    raise ValueError(
+                        "Cohere ASR input feature length exceeds the QPC binding."
+                    )
+                if list(feature_lengths.shape) != target_lengths_shape:
+                    raise ValueError(
+                        "Cohere ASR feature_lengths shape does not match "
+                        "the QPC binding."
+                    )
+                if np.any(feature_lengths < 1) or np.any(
+                    feature_lengths > input_features.shape[-1]
+                ):
+                    raise ValueError(
+                        "Cohere ASR feature_lengths must describe the "
+                        "supplied input features."
+                    )
+                padded_features = np.zeros(
+                    target_features_shape, dtype=target_features_dtype
+                )
+                padded_features[..., : input_features.shape[-1]] = input_features
+                kwargs["input_features"] = padded_features
+                kwargs["feature_lengths"] = feature_lengths.astype(
+                    target_lengths_dtype, copy=False
+                )
+            else:
+                input_features_shape = self.mm_input_info["input_features"][0]
+                kwargs["input_features"] = kwargs["input_features"].reshape(
+                    input_features_shape
+                )
         # Gemma4: vLLM processor outputs position IDs as "pixel_position_ids"
         # but the QPC binding is named "image_position_ids". Rename before filtering.
         if "pixel_position_ids" in kwargs:
@@ -364,7 +435,7 @@ class QaicMultiModal(QaicCausalLM, SupportsMultiModal, SupportsMRoPE):
             else:
                 raise ValueError(f"Unsupported pixel_values type {type(pixel_values)}")
         elif "input_features" in kwargs:
-            # Audio model. Currently only whisper is supported with a single audio input.
+            # QAIC speech models support a single audio input per request.
             num_mm_inputs = 1
         else:
             raise ValueError(f"Unsupported multimodal inputs {kwargs.keys()}")

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -460,19 +460,7 @@ class QaicPlatform(Platform):
 
         if cls.is_aot:
             model_type = model_config.hf_config.model_type
-            if model_type == "cohere_asr":
-                # Register Cohere's QPC-specific processor only for this model.
-                # General QAIC plugin startup must not import Cohere or torchaudio
-                # for unrelated models.
-                from vllm_qaic.model_loader.qaic_custom_mm_processor import (
-                    register_qaic_custom_mm_processor,
-                )
-
-                register_qaic_custom_mm_processor(model_type)
-            elif model_config.is_multimodal_model and model_type not in (
-                "whisper",
-                "cohere_asr",
-            ):
+            if model_config.is_multimodal_model and model_type != "whisper":
                 cls._configure_multimodal_model(
                     vllm_config, model_config, scheduler_config, model_type
                 )

--- a/vllm_qaic/platform_base.py
+++ b/vllm_qaic/platform_base.py
@@ -313,14 +313,15 @@ class QaicPlatform(Platform):
                 cache_config.block_size = model_config.max_model_len  # ctx_len
 
         if cls.is_aot:
-            if model_config.hf_config.model_type == "whisper":
+            if model_config.hf_config.model_type in ("whisper", "cohere_asr"):
                 # Whisper is an encoder-decoder model: vLLM disables chunked prefill
                 # and sets long_prefill_token_threshold to 0, so the formula above
                 # would give 0. Use max_source_positions (the encoder input length)
                 # as the budget instead, matching the pattern in qaic_whisper.py.
-                scheduler_config.max_num_batched_tokens = getattr(
-                    model_config.hf_config, "max_source_positions", 1500
-                )
+                if model_config.hf_config.model_type == "whisper":
+                    scheduler_config.max_num_batched_tokens = getattr(
+                        model_config.hf_config, "max_source_positions", 1500
+                    )
             else:
                 __prefill_seq_len = override_qaic_config.get("prefill_seq_len", 0)
                 if not __prefill_seq_len:
@@ -459,7 +460,19 @@ class QaicPlatform(Platform):
 
         if cls.is_aot:
             model_type = model_config.hf_config.model_type
-            if model_config.is_multimodal_model and model_type != "whisper":
+            if model_type == "cohere_asr":
+                # Register Cohere's QPC-specific processor only for this model.
+                # General QAIC plugin startup must not import Cohere or torchaudio
+                # for unrelated models.
+                from vllm_qaic.model_loader.qaic_custom_mm_processor import (
+                    register_qaic_custom_mm_processor,
+                )
+
+                register_qaic_custom_mm_processor(model_type)
+            elif model_config.is_multimodal_model and model_type not in (
+                "whisper",
+                "cohere_asr",
+            ):
                 cls._configure_multimodal_model(
                     vllm_config, model_config, scheduler_config, model_type
                 )

--- a/vllm_qaic/worker/model_runner.py
+++ b/vllm_qaic/worker/model_runner.py
@@ -1584,6 +1584,12 @@ class QaicModelRunnerAoT(GPUModelRunner):
             return
         if self.model.is_vision_encoder:
             return
+        if self.model.config.model_type == "cohere_asr":
+            # The generic warm-up executes decode before prefill. Cohere ASR
+            # decode requires cross-attention state produced from real encoder
+            # features, so the first request performs the valid warm-up path.
+            logger.debug("Skipping decode-first warm-up for Cohere ASR")
+            return
 
         # Decode (SpD-aware: allocate max_decode_tokens per request)
         decode_bsz = self.model.decode_bsz
@@ -1761,7 +1767,7 @@ class QaicModelRunnerAoT(GPUModelRunner):
 
     def get_supported_generation_tasks(self) -> list[GenerationTask]:
         supported_tasks = list[GenerationTask]()
-        if self.model.config.model_type == "whisper":
+        if self.model.config.model_type in ("whisper", "cohere_asr"):
             supported_tasks.append("transcription")
         else:
             supported_tasks.append("generate")

--- a/vllm_qaic/worker/worker.py
+++ b/vllm_qaic/worker/worker.py
@@ -684,6 +684,21 @@ class QaicWorkerAoT(QaicWorker):
 
         self._configure_thread_parallelism()
 
+        if (
+            self.model_config.is_multimodal_model
+            and self.model_config.hf_config.model_type != "whisper"
+        ):
+            # EngineCore runs in a separate process from the API server, so
+            # register the QAIC processor before it builds the multimodal
+            # budget below, matching platform_base's shared registration path.
+            from vllm_qaic.model_loader.qaic_custom_mm_processor import (
+                register_qaic_custom_mm_processor,
+            )
+
+            register_qaic_custom_mm_processor(
+                self.model_config.hf_config.model_type
+            )
+
         # Construct the model runner
         self.model_runner: QaicModelRunnerAoT = QaicModelRunnerAoT(
             self.vllm_config, self.device


### PR DESCRIPTION
 ## Summary

  Adds batch-size-1 Cohere ASR support through /v1/audio/transcriptions, supporting both prebuilt QPCs and automatic QPC compilation through QEfficient.
  
   ## Validation

  Configuration: one AI100, 8 cores, FP16, BS1, 35-second chunks.
               
   English, 2,620 clips > vLLM-QAIC WER: 1.2601%,    QEff WER: 1.2432%
 
   Arabic, 128 clips  >      vLLM-QAIC WER:     45.7252% , QEff WER:  46.0305%

  Long-audio latency:

  - English 40–60s: 1.045–1.268s.
  - Arabic 40–60s: 1.357–1.610s.

  Existing and freshly compiled QPC paths passed for both languages, and the non-Cohere TinyLlama regression test passed.

  Automatic compilation currently depends on **[quic/efficient-transformers#1275](https://github.com/quic/efficient-transformers/pull/1275);** continuous batching is out of scope.
